### PR TITLE
Fix GitHub pages URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you find Swift Bundler useful, please consider supporting me by [becoming a s
 
 ## Documentation 📚
 
-The documentation is hosted on [GitHub pages](https://stackotter.github.io/swift-bundler/documentation/swiftbundler).
+The documentation is hosted on [GitHub pages](https://swiftbundler.dev/).
 
 ## Installation 📦
 


### PR DESCRIPTION
the original URL(https://stackotter.github.io/swift-bundler/documentation/swiftbundler) doesn't work when adding its own domain to the repository
so I fixed the Link to https://swiftbundler.dev/