### PR TITLE
Add support for visionOS.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -55,12 +55,21 @@
       }
     },
     {
-      "identity" : "swift-argument-parser",
+      "identity" : "stackotter-parser",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/stackotter/swift-argument-parser",
+      "location" : "https://github.com/Wabi-Studios/stackotter-parser.git",
       "state" : {
         "branch" : "main",
-        "revision" : "36f73bea370315e7a5af1f450fa013180ba2c584"
+        "revision" : "6639417d4da09cba76b2dea87362ce3ff1c157db"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "9f39744e025c7d377987f30b03770805dcb0bcd1",
+        "version" : "1.1.4"
       }
     },
     {
@@ -68,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "ce9c0d897db8a840c39de64caaa9b60119cf4be8",
-        "version" : "0.8.1"
+        "revision" : "5da6989aae464f324eef5c5b52bdb7974725ab81",
+        "version" : "1.0.0"
       }
     },
     {
@@ -77,7 +86,16 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-docc-plugin",
       "state" : {
-        "revision" : "3303b164430d9a7055ba484c8ead67a52f7b74f6",
+        "revision" : "26ac5758409154cc448d7ab82389c520fa8a8247",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
         "version" : "1.0.0"
       }
     },
@@ -95,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log",
       "state" : {
-        "revision" : "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
-        "version" : "1.4.2"
+        "revision" : "532d8b529501fb73a2455b179e0bbb6d49b652ed",
+        "version" : "1.5.3"
       }
     },
     {
@@ -113,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-parsing.git",
       "state" : {
-        "revision" : "28d32e9ace1c4c43f5e5a177be837a202494c2d5",
-        "version" : "0.9.2"
+        "revision" : "a0e7d73f462c1c38c59dc40a3969ac40cea42950",
+        "version" : "0.13.0"
       }
     },
     {
@@ -168,7 +186,7 @@
       "location" : "https://github.com/LebJe/TOMLKit",
       "state" : {
         "branch" : "main",
-        "revision" : "3bd15d54d5861e152c1792f1f0b046052190028a"
+        "revision" : "404c4dd011743461bff12d00a5118d0ed59d630c"
       }
     },
     {
@@ -194,8 +212,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "50a70a9d3583fe228ce672e8923010c8df2deddd",
-        "version" : "0.2.1"
+        "revision" : "23cbf2294e350076ea4dbd7d5d047c1e76b03631",
+        "version" : "1.0.2"
       }
     },
     {
@@ -203,8 +221,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jpsim/Yams.git",
       "state" : {
-        "revision" : "f47ba4838c30dbd59998a4e4c87ab620ff959e8a",
-        "version" : "5.0.5"
+        "revision" : "0d9ee7ea8c4ebd4a489ad7a73d5c6cad55d6fed3",
+        "version" : "5.0.6"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.7
 
 import PackageDescription
 
@@ -9,7 +9,7 @@ let package = Package(
     .executable(name: "swift-bundler", targets: ["swift-bundler"])
   ],
   dependencies: [
-    .package(url: "https://github.com/stackotter/swift-argument-parser", branch: "main"),
+    .package(url: "https://github.com/Wabi-Studios/stackotter-parser.git", branch: "main"),
     .package(url: "https://github.com/apple/swift-log", from: "1.4.2"),
     .package(url: "https://github.com/pointfreeco/swift-parsing.git", from: "0.7.1"),
     .package(url: "https://github.com/LebJe/TOMLKit", branch: "main"),
@@ -27,7 +27,7 @@ let package = Package(
     .executableTarget(
       name: "swift-bundler",
       dependencies: [
-        .product(name: "ArgumentParser", package: "swift-argument-parser"),
+        .product(name: "StackOtterArgParser", package: "stackotter-parser"),
         .product(name: "Logging", package: "swift-log"),
         .product(name: "Parsing", package: "swift-parsing"),
         "TOMLKit",

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version:5.6
 
 import PackageDescription
 

--- a/Sources/swift-bundler/Bundler/Bundler.swift
+++ b/Sources/swift-bundler/Bundler/Bundler.swift
@@ -24,6 +24,8 @@ func getBundler(for platform: Platform) -> any Bundler.Type {
       return MacOSBundler.self
     case .iOS, .iOSSimulator:
       return IOSBundler.self
+    case .visionOS, .visionOSSimulator:
+      return VisionOSBundler.self
     case .linux:
       fatalError("Unimplemented")
   }

--- a/Sources/swift-bundler/Bundler/IOSBundler.swift
+++ b/Sources/swift-bundler/Bundler/IOSBundler.swift
@@ -133,9 +133,6 @@ enum IOSBundler: Bundler {
   /// Creates the following structure:
   ///
   /// - `AppName.app`
-  ///   - `Contents`
-  ///     - `MacOS`
-  ///     - `Resources`
   ///     - `Libraries`
   ///
   /// If the app directory already exists, it is deleted before continuing.

--- a/Sources/swift-bundler/Bundler/PlistCreator.swift
+++ b/Sources/swift-bundler/Bundler/PlistCreator.swift
@@ -98,10 +98,15 @@ enum PlistCreator {
         entries["CFBundleSupportedPlatforms"] = ["iPhoneOS"]
         entries["UILaunchScreen"] = [String: Any]()
       case .visionOS, .visionOSSimulator:
+        // using Apple's HelloWorld visionOS demo as a reference
+        // ref: https://developer.apple.com/documentation/visionos/world
         entries["MinimumOSVersion"] = platformVersion
         entries["CFBundleSupportedPlatforms"] = ["XROS"]
-        entries["UIApplicationSceneManifest"] = [String: Any]()
-        entries["UISceneConfigurations"] = [String: Any]()
+        entries["UIApplicationSceneManifest"] = [
+          "UIApplicationSupportsMultipleScenes": true,
+          "UISceneConfigurations": [String: Any](),
+        ]
+        entries["UINativeSizeClass"] = 1
         entries["UIDeviceFamily"] = [7]
       case .linux:
         break

--- a/Sources/swift-bundler/Bundler/PlistCreator.swift
+++ b/Sources/swift-bundler/Bundler/PlistCreator.swift
@@ -90,27 +90,28 @@ enum PlistCreator {
     ]
 
     switch platform {
-      case .macOS:
-        entries["LSMinimumSystemVersion"] = platformVersion
-        entries["CFBundleSupportedPlatforms"] = ["MacOSX"]
-      case .iOS, .iOSSimulator:
-        entries["MinimumOSVersion"] = platformVersion
-        entries["CFBundleSupportedPlatforms"] = ["iPhoneOS"]
-        entries["UILaunchScreen"] = [String: Any]()
-      case .visionOS, .visionOSSimulator:
-        entries["MinimumOSVersion"] = platformVersion
-        entries["CFBundleSupportedPlatforms"] = ["XROS"]
-        entries["UISceneConfigurations"] = [String: Any]()
-        entries["UIDeviceFamily"] = [7]
-      case .linux:
-        break
+    case .macOS:
+      entries["LSMinimumSystemVersion"] = platformVersion
+      entries["CFBundleSupportedPlatforms"] = ["MacOSX"]
+    case .iOS, .iOSSimulator:
+      entries["MinimumOSVersion"] = platformVersion
+      entries["CFBundleSupportedPlatforms"] = ["iPhoneOS"]
+      entries["UILaunchScreen"] = [String: Any]()
+    case .visionOS, .visionOSSimulator:
+      entries["MinimumOSVersion"] = platformVersion
+      entries["CFBundleSupportedPlatforms"] = ["XROS"]
+      entries["UIApplicationSceneManifest"] = [String: Any]()
+      entries["UISceneConfigurations"] = [String: Any]()
+      entries["UIDeviceFamily"] = [7]
+    case .linux:
+      break
     }
 
     for (key, value) in configuration.plist ?? [:] {
       entries[key] = value.value
     }
 
-    return Self.serialize(entries.compactMapValues { $0 })
+    return serialize(entries.compactMapValues { $0 })
   }
 
   /// Creates the contents of a resource bundle's `Info.plist` file.
@@ -133,22 +134,22 @@ enum PlistCreator {
     ]
 
     switch platform {
-      case .macOS:
-        entries["LSMinimumSystemVersion"] = platformVersion
-        entries["CFBundleSupportedPlatforms"] = ["MacOSX"]
-      case .iOS, .iOSSimulator:
-        // TODO: Make the produced Info.plist for iOS identical to Xcode's
-        entries["MinimumOSVersion"] = platformVersion
-        entries["CFBundleSupportedPlatforms"] = ["iPhoneOS"]
-      case .visionOS, .visionOSSimulator:
-        // TODO: Make the produced Info.plist for visionOS identical to Xcode's
-        entries["MinimumOSVersion"] = platformVersion
-        entries["CFBundleSupportedPlatforms"] = ["XROS"]
-      case .linux:
-        break
+    case .macOS:
+      entries["LSMinimumSystemVersion"] = platformVersion
+      entries["CFBundleSupportedPlatforms"] = ["MacOSX"]
+    case .iOS, .iOSSimulator:
+      // TODO: Make the produced Info.plist for iOS identical to Xcode's
+      entries["MinimumOSVersion"] = platformVersion
+      entries["CFBundleSupportedPlatforms"] = ["iPhoneOS"]
+    case .visionOS, .visionOSSimulator:
+      // TODO: Make the produced Info.plist for visionOS identical to Xcode's
+      entries["MinimumOSVersion"] = platformVersion
+      entries["CFBundleSupportedPlatforms"] = ["XROS"]
+    case .linux:
+      break
     }
 
-    return Self.serialize(entries.compactMapValues { $0 })
+    return serialize(entries.compactMapValues { $0 })
   }
 
   /// Serializes a plist dictionary into an `xml` format.
@@ -157,7 +158,8 @@ enum PlistCreator {
   static func serialize(_ entries: [String: Any]) -> Result<Data, PlistCreatorError> {
     do {
       let data = try PropertyListSerialization.data(
-        fromPropertyList: entries, format: .xml, options: 0)
+        fromPropertyList: entries, format: .xml, options: 0
+      )
       return .success(data)
     } catch {
       return .failure(.serializationFailed(error))

--- a/Sources/swift-bundler/Bundler/PlistCreator.swift
+++ b/Sources/swift-bundler/Bundler/PlistCreator.swift
@@ -97,6 +97,10 @@ enum PlistCreator {
         entries["MinimumOSVersion"] = platformVersion
         entries["CFBundleSupportedPlatforms"] = ["iPhoneOS"]
         entries["UILaunchScreen"] = [String: Any]()
+      case .visionOS, .visionOSSimulator:
+        entries["MinimumOSVersion"] = platformVersion
+        entries["CFBundleSupportedPlatforms"] = ["XROS"]
+        entries["UISceneConfigurations"] = [String: Any]()
       case .linux:
         break
     }
@@ -135,6 +139,10 @@ enum PlistCreator {
         // TODO: Make the produced Info.plist for iOS identical to Xcode's
         entries["MinimumOSVersion"] = platformVersion
         entries["CFBundleSupportedPlatforms"] = ["iPhoneOS"]
+      case .visionOS, .visionOSSimulator:
+        // TODO: Make the produced Info.plist for visionOS identical to Xcode's
+        entries["MinimumOSVersion"] = platformVersion
+        entries["CFBundleSupportedPlatforms"] = ["XROS"]
       case .linux:
         break
     }

--- a/Sources/swift-bundler/Bundler/PlistCreator.swift
+++ b/Sources/swift-bundler/Bundler/PlistCreator.swift
@@ -90,28 +90,28 @@ enum PlistCreator {
     ]
 
     switch platform {
-    case .macOS:
-      entries["LSMinimumSystemVersion"] = platformVersion
-      entries["CFBundleSupportedPlatforms"] = ["MacOSX"]
-    case .iOS, .iOSSimulator:
-      entries["MinimumOSVersion"] = platformVersion
-      entries["CFBundleSupportedPlatforms"] = ["iPhoneOS"]
-      entries["UILaunchScreen"] = [String: Any]()
-    case .visionOS, .visionOSSimulator:
-      entries["MinimumOSVersion"] = platformVersion
-      entries["CFBundleSupportedPlatforms"] = ["XROS"]
-      entries["UIApplicationSceneManifest"] = [String: Any]()
-      entries["UISceneConfigurations"] = [String: Any]()
-      entries["UIDeviceFamily"] = [7]
-    case .linux:
-      break
+      case .macOS:
+        entries["LSMinimumSystemVersion"] = platformVersion
+        entries["CFBundleSupportedPlatforms"] = ["MacOSX"]
+      case .iOS, .iOSSimulator:
+        entries["MinimumOSVersion"] = platformVersion
+        entries["CFBundleSupportedPlatforms"] = ["iPhoneOS"]
+        entries["UILaunchScreen"] = [String: Any]()
+      case .visionOS, .visionOSSimulator:
+        entries["MinimumOSVersion"] = platformVersion
+        entries["CFBundleSupportedPlatforms"] = ["XROS"]
+        entries["UIApplicationSceneManifest"] = [String: Any]()
+        entries["UISceneConfigurations"] = [String: Any]()
+        entries["UIDeviceFamily"] = [7]
+      case .linux:
+        break
     }
 
     for (key, value) in configuration.plist ?? [:] {
       entries[key] = value.value
     }
 
-    return serialize(entries.compactMapValues { $0 })
+    return Self.serialize(entries.compactMapValues { $0 })
   }
 
   /// Creates the contents of a resource bundle's `Info.plist` file.
@@ -134,22 +134,22 @@ enum PlistCreator {
     ]
 
     switch platform {
-    case .macOS:
-      entries["LSMinimumSystemVersion"] = platformVersion
-      entries["CFBundleSupportedPlatforms"] = ["MacOSX"]
-    case .iOS, .iOSSimulator:
-      // TODO: Make the produced Info.plist for iOS identical to Xcode's
-      entries["MinimumOSVersion"] = platformVersion
-      entries["CFBundleSupportedPlatforms"] = ["iPhoneOS"]
-    case .visionOS, .visionOSSimulator:
-      // TODO: Make the produced Info.plist for visionOS identical to Xcode's
-      entries["MinimumOSVersion"] = platformVersion
-      entries["CFBundleSupportedPlatforms"] = ["XROS"]
-    case .linux:
-      break
+      case .macOS:
+        entries["LSMinimumSystemVersion"] = platformVersion
+        entries["CFBundleSupportedPlatforms"] = ["MacOSX"]
+      case .iOS, .iOSSimulator:
+        // TODO: Make the produced Info.plist for iOS identical to Xcode's
+        entries["MinimumOSVersion"] = platformVersion
+        entries["CFBundleSupportedPlatforms"] = ["iPhoneOS"]
+      case .visionOS, .visionOSSimulator:
+        // TODO: Make the produced Info.plist for visionOS identical to Xcode's
+        entries["MinimumOSVersion"] = platformVersion
+        entries["CFBundleSupportedPlatforms"] = ["XROS"]
+      case .linux:
+        break
     }
 
-    return serialize(entries.compactMapValues { $0 })
+    return Self.serialize(entries.compactMapValues { $0 })
   }
 
   /// Serializes a plist dictionary into an `xml` format.
@@ -158,8 +158,7 @@ enum PlistCreator {
   static func serialize(_ entries: [String: Any]) -> Result<Data, PlistCreatorError> {
     do {
       let data = try PropertyListSerialization.data(
-        fromPropertyList: entries, format: .xml, options: 0
-      )
+        fromPropertyList: entries, format: .xml, options: 0)
       return .success(data)
     } catch {
       return .failure(.serializationFailed(error))

--- a/Sources/swift-bundler/Bundler/PlistCreator.swift
+++ b/Sources/swift-bundler/Bundler/PlistCreator.swift
@@ -101,6 +101,7 @@ enum PlistCreator {
         entries["MinimumOSVersion"] = platformVersion
         entries["CFBundleSupportedPlatforms"] = ["XROS"]
         entries["UISceneConfigurations"] = [String: Any]()
+        entries["UIDeviceFamily"] = [7]
       case .linux:
         break
     }

--- a/Sources/swift-bundler/Bundler/ResourceBundler.swift
+++ b/Sources/swift-bundler/Bundler/ResourceBundler.swift
@@ -153,9 +153,7 @@ enum ResourceBundler {
         case .macOS:
           destinationBundleResources = destinationBundle.appendingPathComponent(
             "Contents/Resources")
-        case .iOS, .iOSSimulator:
-          destinationBundleResources = destinationBundle
-        case .visionOS, .visionOSSimulator:
+        case .iOS, .iOSSimulator, .visionOS, .visionOSSimulator:
           destinationBundleResources = destinationBundle
         case .linux:
           // TODO: Implement on linux
@@ -242,9 +240,7 @@ enum ResourceBundler {
         let bundleContents = bundle.appendingPathComponent("Contents")
         let bundleResources = bundleContents.appendingPathComponent("Resources")
         directory = bundleResources
-      case .iOS, .iOSSimulator:
-        directory = bundle
-      case .visionOS, .visionOSSimulator:
+      case .iOS, .iOSSimulator, .visionOS, .visionOSSimulator:
         directory = bundle
       case .linux:
         // TODO: Implement for linux
@@ -280,11 +276,7 @@ enum ResourceBundler {
           bundle
           .appendingPathComponent("Contents")
           .appendingPathComponent("Info.plist")
-      case .iOS, .iOSSimulator:
-        infoPlist =
-          bundle
-          .appendingPathComponent("Info.plist")
-      case .visionOS, .visionOSSimulator:
+      case .iOS, .iOSSimulator, .visionOS, .visionOSSimulator:
         infoPlist =
           bundle
           .appendingPathComponent("Info.plist")

--- a/Sources/swift-bundler/Bundler/ResourceBundler.swift
+++ b/Sources/swift-bundler/Bundler/ResourceBundler.swift
@@ -155,6 +155,8 @@ enum ResourceBundler {
             "Contents/Resources")
         case .iOS, .iOSSimulator:
           destinationBundleResources = destinationBundle
+        case .visionOS, .visionOSSimulator:
+          destinationBundleResources = destinationBundle
         case .linux:
           // TODO: Implement on linux
           fatalError("TODO: Implement resource bundling for linux")
@@ -242,6 +244,8 @@ enum ResourceBundler {
         directory = bundleResources
       case .iOS, .iOSSimulator:
         directory = bundle
+      case .visionOS, .visionOSSimulator:
+        directory = bundle
       case .linux:
         // TODO: Implement for linux
         fatalError("TODO: Implement resource bundling on linux")
@@ -277,6 +281,10 @@ enum ResourceBundler {
           .appendingPathComponent("Contents")
           .appendingPathComponent("Info.plist")
       case .iOS, .iOSSimulator:
+        infoPlist =
+          bundle
+          .appendingPathComponent("Info.plist")
+      case .visionOS, .visionOSSimulator:
         infoPlist =
           bundle
           .appendingPathComponent("Info.plist")

--- a/Sources/swift-bundler/Bundler/Runner/Device.swift
+++ b/Sources/swift-bundler/Bundler/Runner/Device.swift
@@ -4,6 +4,8 @@ import Foundation
 enum Device {
   case macOS
   case iOS
+  case visionOS
   case linux
   case iOSSimulator(id: String)
+  case visionOSSimulator(id: String)
 }

--- a/Sources/swift-bundler/Bundler/Runner/Runner.swift
+++ b/Sources/swift-bundler/Bundler/Runner/Runner.swift
@@ -215,10 +215,10 @@ enum Runner {
     arguments: [String],
     environmentVariables: [String: String]
   ) -> Result<Void, RunnerError> {
-    // `xros-deploy` is explicitly resolved (instead of allowing `Process.create`
+    // `ios-deploy` is explicitly resolved (instead of allowing `Process.create`
     // to handle running programs located on the user's PATH) so that a detailed
     // error message can be emitted for this easy misconfiguration issue.
-    return Process.locate("xros-deploy").mapError { error in
+    return Process.locate("ios-deploy").mapError { error in
       .failedToLocateVisionOSDeploy(error)
     }.flatMap { xrosDeployExecutable in
       let environmentArguments: [String]

--- a/Sources/swift-bundler/Bundler/Runner/Runner.swift
+++ b/Sources/swift-bundler/Bundler/Runner/Runner.swift
@@ -219,7 +219,7 @@ enum Runner {
     // to handle running programs located on the user's PATH) so that a detailed
     // error message can be emitted for this easy misconfiguration issue.
     return Process.locate("ios-deploy").mapError { error in
-      .failedToLocateVisionOSDeploy(error)
+      .failedToLocateIOSDeploy(error)
     }.flatMap { xrosDeployExecutable in
       let environmentArguments: [String]
       if !environmentVariables.isEmpty {
@@ -243,7 +243,7 @@ enum Runner {
           },
         runSilentlyWhenNotVerbose: false
       ).runAndWait().mapError { error in
-        .failedToRunVisionOSDeploy(error)
+        .failedToRunIOSDeploy(error)
       }
     }
   }

--- a/Sources/swift-bundler/Bundler/Runner/Runner.swift
+++ b/Sources/swift-bundler/Bundler/Runner/Runner.swift
@@ -52,6 +52,20 @@ enum Runner {
           arguments: arguments,
           environmentVariables: environmentVariables
         )
+      case .visionOS:
+        return runVisionOSApp(
+          bundle: bundle,
+          arguments: arguments,
+          environmentVariables: environmentVariables
+        )
+      case .visionOSSimulator(let id):
+        return runVisionOSSimulatorApp(
+          bundle: bundle,
+          bundleIdentifier: bundleIdentifier,
+          simulatorId: id,
+          arguments: arguments,
+          environmentVariables: environmentVariables
+        )
       case .linux:
         // TODO: Implement linux app running
         fatalError("TODO: Implement linux app running")
@@ -187,6 +201,86 @@ enum Runner {
       )
     }.mapError { error in
       return .failedToRunOnIOSSimulator(error)
+    }
+  }
+
+  /// Runs an app on the first connected visionOS device.
+  /// - Parameters:
+  ///   - bundle: The app bundle to run.
+  ///   - arguments: Command line arguments to pass to the app.
+  ///   - environmentVariables: Environment variables to pass to the app.
+  /// - Returns: A failure if an error occurs.
+  static func runVisionOSApp(
+    bundle: URL,
+    arguments: [String],
+    environmentVariables: [String: String]
+  ) -> Result<Void, RunnerError> {
+    // `xros-deploy` is explicitly resolved (instead of allowing `Process.create`
+    // to handle running programs located on the user's PATH) so that a detailed
+    // error message can be emitted for this easy misconfiguration issue.
+    return Process.locate("xros-deploy").mapError { error in
+      .failedToLocateVisionOSDeploy(error)
+    }.flatMap { xrosDeployExecutable in
+      let environmentArguments: [String]
+      if !environmentVariables.isEmpty {
+        // TODO: correctly escape keys and values
+        let value = environmentVariables.map { key, value in
+          "\(key)=\(value)"
+        }.joined(separator: " ")
+        environmentArguments = ["--envs", "\(value)"]
+      } else {
+        environmentArguments = []
+      }
+
+      return Process.create(
+        xrosDeployExecutable,
+        arguments: [
+          "--noninteractive",
+          "--bundle", bundle.path,
+        ] + environmentArguments
+          + arguments.flatMap { argument in
+            ["--args", argument]
+          },
+        runSilentlyWhenNotVerbose: false
+      ).runAndWait().mapError { error in
+        .failedToRunVisionOSDeploy(error)
+      }
+    }
+  }
+
+  /// Runs an app on an visionOS simulator.
+  /// - Parameters:
+  ///   - bundle: The app bundle to run.
+  ///   - bundleIdentifier: The app's identifier.
+  ///   - simulatorId: The id of the simulator to run.
+  ///   - arguments: Command line arguments to pass to the app.
+  ///   - environmentVariables: Environment variables to pass to the app.
+  /// - Returns: A failure if an error occurs.
+  static func runVisionOSSimulatorApp(
+    bundle: URL,
+    bundleIdentifier: String,
+    simulatorId: String,
+    arguments: [String],
+    environmentVariables: [String: String]
+  ) -> Result<Void, RunnerError> {
+    log.info("Preparing simulator")
+    return SimulatorManager.bootSimulator(id: simulatorId).flatMap { _ in
+      log.info("Installing app")
+      return SimulatorManager.installApp(bundle, simulatorId: simulatorId)
+    }.flatMap { (_: Void) -> Result<Void, SimulatorManagerError> in
+      log.info("Opening Simulator")
+      return SimulatorManager.openSimulatorApp()
+    }.flatMap { (_: Void) -> Result<Void, SimulatorManagerError> in
+      log.info("Launching \(bundleIdentifier)")
+      return SimulatorManager.launchApp(
+        bundleIdentifier,
+        simulatorId: simulatorId,
+        connectConsole: true,
+        arguments: arguments,
+        environmentVariables: environmentVariables
+      )
+    }.mapError { error in
+      .failedToRunOnVisionOSSimulator(error)
     }
   }
 }

--- a/Sources/swift-bundler/Bundler/Runner/RunnerError.swift
+++ b/Sources/swift-bundler/Bundler/Runner/RunnerError.swift
@@ -5,8 +5,6 @@ enum RunnerError: LocalizedError {
   case failedToRunExecutable(ProcessError)
   case failedToLocateIOSDeploy(ProcessError)
   case failedToRunIOSDeploy(ProcessError)
-  case failedToLocateVisionOSDeploy(ProcessError)
-  case failedToRunVisionOSDeploy(ProcessError)
   case failedToReadEnvironmentFile(URL, Error)
   case failedToParseEnvironmentFileEntry(line: String)
   case failedToRunOnIOSSimulator(SimulatorManagerError)
@@ -18,22 +16,12 @@ enum RunnerError: LocalizedError {
         return "Failed to run executable: \(error)"
       case .failedToLocateIOSDeploy:
         return Output {
-          "'ios-deploy' must be installed to run apps on iOS"
+          "'ios-deploy' must be installed to run apps on iOS and visionOS"
           ExampleCommand("brew install ios-deploy")
         }.body
       case .failedToRunIOSDeploy:
         return Output {
           "Failed to run 'ios-deploy'"
-          "Have you trusted the provisioning profile in settings? (General > VPN & Device Management)"
-        }.body
-      case .failedToLocateVisionOSDeploy:
-        return Output {
-          "'xros-deploy' must be installed to run apps on visionOS"
-          ExampleCommand("brew install xros-deploy")
-        }.body
-      case .failedToRunVisionOSDeploy:
-        return Output {
-          "Failed to run 'xros-deploy'"
           "Have you trusted the provisioning profile in settings? (General > VPN & Device Management)"
         }.body
       case let .failedToReadEnvironmentFile(file, _):

--- a/Sources/swift-bundler/Bundler/Runner/RunnerError.swift
+++ b/Sources/swift-bundler/Bundler/Runner/RunnerError.swift
@@ -5,9 +5,12 @@ enum RunnerError: LocalizedError {
   case failedToRunExecutable(ProcessError)
   case failedToLocateIOSDeploy(ProcessError)
   case failedToRunIOSDeploy(ProcessError)
+  case failedToLocateVisionOSDeploy(ProcessError)
+  case failedToRunVisionOSDeploy(ProcessError)
   case failedToReadEnvironmentFile(URL, Error)
   case failedToParseEnvironmentFileEntry(line: String)
   case failedToRunOnIOSSimulator(SimulatorManagerError)
+  case failedToRunOnVisionOSSimulator(SimulatorManagerError)
 
   var errorDescription: String? {
     switch self {
@@ -23,12 +26,24 @@ enum RunnerError: LocalizedError {
           "Failed to run 'ios-deploy'"
           "Have you trusted the provisioning profile in settings? (General > VPN & Device Management)"
         }.body
-      case .failedToReadEnvironmentFile(let file, _):
+      case .failedToLocateVisionOSDeploy:
+        return Output {
+          "'xros-deploy' must be installed to run apps on visionOS"
+          ExampleCommand("brew install xros-deploy")
+        }.body
+      case .failedToRunVisionOSDeploy:
+        return Output {
+          "Failed to run 'xros-deploy'"
+          "Have you trusted the provisioning profile in settings? (General > VPN & Device Management)"
+        }.body
+      case let .failedToReadEnvironmentFile(file, _):
         return "Failed to read contents of environment file '\(file.relativePath)'"
-      case .failedToParseEnvironmentFileEntry(let line):
+      case let .failedToParseEnvironmentFileEntry(line):
         return "Failed to parse environment file, lines must contain '=': '\(line)'"
-      case .failedToRunOnIOSSimulator(let error):
+      case let .failedToRunOnIOSSimulator(error):
         return "Failed to run app on iOS simulator: \(error.localizedDescription)"
+      case let .failedToRunOnVisionOSSimulator(error):
+        return "Failed to run app on visionOS simulator: \(error.localizedDescription)"
     }
   }
 }

--- a/Sources/swift-bundler/Bundler/SimulatorManager/SimulatorManager.swift
+++ b/Sources/swift-bundler/Bundler/SimulatorManager/SimulatorManager.swift
@@ -27,6 +27,9 @@ enum SimulatorManager {
         if platform.hasPrefix("com.apple.CoreSimulator.SimRuntime.iOS") {
           simulators.append(contentsOf: platformSimulators)
         }
+        if platform.hasPrefix("com.apple.CoreSimulator.SimRuntime.xrOS") {
+          simulators.append(contentsOf: platformSimulators)
+        }
       }
 
       return .success(simulators)

--- a/Sources/swift-bundler/Bundler/SwiftPackageManager/BuildArchitecture.swift
+++ b/Sources/swift-bundler/Bundler/SwiftPackageManager/BuildArchitecture.swift
@@ -1,5 +1,5 @@
-import ArgumentParser
 import Foundation
+import StackOtterArgParser
 
 /// An architecture to build for.
 enum BuildArchitecture: String, CaseIterable, ExpressibleByArgument {

--- a/Sources/swift-bundler/Bundler/SwiftPackageManager/Platform.swift
+++ b/Sources/swift-bundler/Bundler/SwiftPackageManager/Platform.swift
@@ -26,7 +26,7 @@ enum Platform: String, CaseIterable {
       case .visionOS:
         return "xros"
       case .visionOSSimulator:
-        return "xrossimulator"
+        return "xrsimulator"
       case .linux:
         return "linux"
     }

--- a/Sources/swift-bundler/Bundler/SwiftPackageManager/Platform.swift
+++ b/Sources/swift-bundler/Bundler/SwiftPackageManager/Platform.swift
@@ -5,6 +5,8 @@ enum Platform: String, CaseIterable {
   case macOS
   case iOS
   case iOSSimulator
+  case visionOS
+  case visionOSSimulator
   case linux
 
   /// The platform's name.
@@ -21,6 +23,10 @@ enum Platform: String, CaseIterable {
         return "iphoneos"
       case .iOSSimulator:
         return "iphonesimulator"
+      case .visionOS:
+        return "xros"
+      case .visionOSSimulator:
+        return "xrossimulator"
       case .linux:
         return "linux"
     }
@@ -29,9 +35,9 @@ enum Platform: String, CaseIterable {
   /// Whether the platform is a simulator or not.
   var isSimulator: Bool {
     switch self {
-      case .iOSSimulator:
+      case .iOSSimulator, .visionOSSimulator:
         return true
-      case .macOS, .iOS, .linux:
+      case .macOS, .iOS, .visionOS, .linux:
         return false
     }
   }
@@ -39,10 +45,12 @@ enum Platform: String, CaseIterable {
   /// The platform's name in a SwiftPM manifest's JSON representation.
   var manifestName: String {
     switch self {
-      case .macOS, .iOS, .linux:
+      case .macOS, .iOS, .visionOS, .linux:
         return name.lowercased()
       case .iOSSimulator:
         return Platform.iOS.name.lowercased()
+      case .visionOSSimulator:
+        return Platform.visionOS.name.lowercased()
     }
   }
 

--- a/Sources/swift-bundler/Bundler/SwiftPackageManager/SwiftPackageManager.swift
+++ b/Sources/swift-bundler/Bundler/SwiftPackageManager/SwiftPackageManager.swift
@@ -373,19 +373,7 @@ enum SwiftPackageManager {
         toolsVersion = output.trimmingCharacters(in: .whitespacesAndNewlines)
         swiftMajorVersion = String(toolsVersion.first!)
       case .failure(let error):
-        // Provide a fallback tools version for when the tools version cannot be parsed.
-        #if swift(>=6.0)
-          // with Swift 6 just around the corner...
-          let pkgDescVersion = "6.0.0"
-        #elseif swift(>=5.9)
-          // targeting visionOS needs a minimum tools version of 5.9.
-          let pkgDescVersion = "5.9.0"
-        #else
-          let pkgDescVersion = "5.5.0"
-        #endif
-        toolsVersion = pkgDescVersion
-        swiftMajorVersion = String(toolsVersion.first!)
-        return .failure(.failedToParsePackageManifestToolsVersion(fallbackVersion: toolsVersion, error))
+        return .failure(.failedToParsePackageManifestToolsVersion(error))
     }
 
     // Compile to object file

--- a/Sources/swift-bundler/Bundler/SwiftPackageManager/SwiftPackageManager.swift
+++ b/Sources/swift-bundler/Bundler/SwiftPackageManager/SwiftPackageManager.swift
@@ -1,6 +1,6 @@
-import ArgumentParser
 import Foundation
 import Parsing
+import StackOtterArgParser
 import Version
 
 /// A utility for interacting with the Swift package manager and performing some other package
@@ -157,6 +157,46 @@ enum SwiftPackageManager {
         // TODO: Make target triple generation generic
         let architecture = BuildArchitecture.current.rawValue
         let targetTriple = "\(architecture)-apple-ios\(platformVersion)-simulator"
+        platformArguments =
+          [
+            "-sdk", sdkPath,
+            "-target", targetTriple,
+          ].flatMap { ["-Xswiftc", $0] }
+          + [
+            "--target=\(targetTriple)",
+            "-isysroot", sdkPath,
+          ].flatMap { ["-Xcc", $0] }
+      case .visionOS:
+        let sdkPath: String
+        switch getLatestSDKPath(for: platform) {
+        case let .success(path):
+          sdkPath = path
+        case let .failure(error):
+          return .failure(error)
+        }
+
+        let targetTriple = "arm64-apple-xros\(platformVersion)"
+        platformArguments =
+          [
+            "-sdk", sdkPath,
+            "-target", targetTriple,
+          ].flatMap { ["-Xswiftc", $0] }
+          + [
+            "--target=\(targetTriple)",
+            "-isysroot", sdkPath,
+          ].flatMap { ["-Xcc", $0] }
+      case .visionOSSimulator:
+        let sdkPath: String
+        switch getLatestSDKPath(for: platform) {
+        case let .success(path):
+          sdkPath = path
+        case let .failure(error):
+          return .failure(error)
+        }
+
+        // TODO: Make target triple generation generic
+        let architecture = BuildArchitecture.current.rawValue
+        let targetTriple = "\(architecture)-apple-xros\(platformVersion)-simulator"
         platformArguments =
           [
             "-sdk", sdkPath,

--- a/Sources/swift-bundler/Bundler/SwiftPackageManager/SwiftPackageManager.swift
+++ b/Sources/swift-bundler/Bundler/SwiftPackageManager/SwiftPackageManager.swift
@@ -404,13 +404,20 @@ enum SwiftPackageManager {
     #endif
 
     // Compile to object file
+    #if swift(>=5.9)
+      // Without this, visionOS is unable to target.
+      let pkgDescVersion = "5.9.0"
+    #else
+      // TODO: Parse version from manifest comment
+      let pkgDescVersion = "5.5.0"
+    #endif
     let swiftArguments =
       [
         manifestPath,
         "-I", manifestAPIDirectory.path,
         "-Xlinker", "-rpath", "-Xlinker", manifestAPIDirectory.path,
         "-lPackageDescription",
-        "-swift-version", "5", "-package-description-version", "5.5.0",  // TODO: Parse version from manifest comment
+        "-swift-version", "5", "-package-description-version", pkgDescVersion,  
         "-disable-implicit-concurrency-module-import",
         "-disable-implicit-string-processing-module-import",
         "-o", temporaryExecutableFile,

--- a/Sources/swift-bundler/Bundler/SwiftPackageManager/SwiftPackageManagerError.swift
+++ b/Sources/swift-bundler/Bundler/SwiftPackageManager/SwiftPackageManagerError.swift
@@ -17,6 +17,7 @@ enum SwiftPackageManagerError: LocalizedError {
   case failedToLinkPackageManifest(Error)
   case failedToExecutePackageManifest(Error)
   case failedToParsePackageManifestOutput(json: String, Error?)
+  case failedToParsePackageManifestToolsVersion(fallbackVersion: String, Error?)
 
   var errorDescription: String? {
     switch self {
@@ -57,6 +58,11 @@ enum SwiftPackageManagerError: LocalizedError {
         // make that weak assumption about the implementation
         return
           "Failed to parse package manifest output: \(error?.localizedDescription ?? "Unknown error")"
+      case .failedToParsePackageManifestToolsVersion(let fallbackVersion, let error):
+        return """
+          Failed to parse package manifest tools version: \(error?.localizedDescription ?? "Unknown error")
+          Falling back to tools version \(fallbackVersion), which may fail to build with your target.
+          """
     }
   }
 }

--- a/Sources/swift-bundler/Bundler/SwiftPackageManager/SwiftPackageManagerError.swift
+++ b/Sources/swift-bundler/Bundler/SwiftPackageManager/SwiftPackageManagerError.swift
@@ -17,7 +17,7 @@ enum SwiftPackageManagerError: LocalizedError {
   case failedToLinkPackageManifest(Error)
   case failedToExecutePackageManifest(Error)
   case failedToParsePackageManifestOutput(json: String, Error?)
-  case failedToParsePackageManifestToolsVersion(fallbackVersion: String, Error?)
+  case failedToParsePackageManifestToolsVersion(Error?)
 
   var errorDescription: String? {
     switch self {
@@ -58,10 +58,9 @@ enum SwiftPackageManagerError: LocalizedError {
         // make that weak assumption about the implementation
         return
           "Failed to parse package manifest output: \(error?.localizedDescription ?? "Unknown error")"
-      case .failedToParsePackageManifestToolsVersion(let fallbackVersion, let error):
+      case .failedToParsePackageManifestToolsVersion(let error):
         return """
           Failed to parse package manifest tools version: \(error?.localizedDescription ?? "Unknown error")
-          Falling back to tools version \(fallbackVersion), which may fail to build with your target.
           """
     }
   }

--- a/Sources/swift-bundler/Bundler/Templater/IndentationStyle.swift
+++ b/Sources/swift-bundler/Bundler/Templater/IndentationStyle.swift
@@ -1,5 +1,5 @@
-import ArgumentParser
 import Parsing
+import StackOtterArgParser
 
 /// A style of code indentation.
 enum IndentationStyle: Equatable {

--- a/Sources/swift-bundler/Bundler/VisionOSBundler.swift
+++ b/Sources/swift-bundler/Bundler/VisionOSBundler.swift
@@ -133,9 +133,6 @@ enum VisionOSBundler: Bundler {
   /// Creates the following structure:
   ///
   /// - `AppName.app`
-  ///   - `Contents`
-  ///     - `MacOS`
-  ///     - `Resources`
   ///     - `Libraries`
   ///
   /// If the app directory already exists, it is deleted before continuing.

--- a/Sources/swift-bundler/Bundler/VisionOSBundler.swift
+++ b/Sources/swift-bundler/Bundler/VisionOSBundler.swift
@@ -1,0 +1,260 @@
+import Foundation
+
+/// The bundler for creating visionOS apps.
+enum VisionOSBundler: Bundler {
+  /// Bundles the built executable and resources into an visionOS app.
+  ///
+  /// ``build(product:in:buildConfiguration:universal:)`` should usually be called first.
+  /// - Parameters:
+  ///   - appName: The name to give the bundled app.
+  ///   - packageName: The name of the package.
+  ///   - appConfiguration: The app's configuration.
+  ///   - packageDirectory: The root directory of the package containing the app.
+  ///   - productsDirectory: The directory containing the products from the build step.
+  ///   - outputDirectory: The directory to output the app into.
+  ///   - isXcodeBuild: Does nothing for visionOS.
+  ///   - universal: Does nothing for visionOS.
+  ///   - standAlone: If `true`, the app bundle will not depend on any system-wide dependencies
+  ///     being installed (such as gtk).
+  ///   - codesigningIdentity: If not `nil`, the app will be codesigned using the given identity.
+  ///   - provisioningProfile: If not `nil`, this provisioning profile will get embedded in the app.
+  ///   - platformVersion: The platform version that the executable was built for.
+  ///   - targetingSimulator: If `true`, the app should be bundled for running on a simulator.
+  /// - Returns: If a failure occurs, it is returned.
+  static func bundle(
+    appName: String,
+    packageName: String,
+    appConfiguration: AppConfiguration,
+    packageDirectory _: URL,
+    productsDirectory: URL,
+    outputDirectory: URL,
+    isXcodeBuild: Bool,
+    universal: Bool,
+    standAlone _: Bool,
+    codesigningIdentity: String?,
+    provisioningProfile: URL?,
+    platformVersion: String,
+    targetingSimulator: Bool
+  ) -> Result<Void, Error> {
+    log.info("Bundling '\(appName).app'")
+
+    let executableArtifact = productsDirectory.appendingPathComponent(appConfiguration.product)
+
+    let appBundle = outputDirectory.appendingPathComponent("\(appName).app")
+    let appExecutable = appBundle.appendingPathComponent(appName)
+    let appDynamicLibrariesDirectory = appBundle.appendingPathComponent("Libraries")
+
+    // let createAppIconIfPresent: () -> Result<Void, VisionOSBundlerError> = {
+    //   if let path = appConfiguration.icon {
+    //     let icon = packageDirectory.appendingPathComponent(path)
+    //     return Self.createAppIcon(icon: icon, outputDirectory: appAssets)
+    //   }
+    //   return .success()
+    // }
+
+    let copyResourcesBundles: () -> Result<Void, VisionOSBundlerError> = {
+      ResourceBundler.copyResources(
+        from: productsDirectory,
+        to: appBundle,
+        fixBundles: !isXcodeBuild && !universal,
+        platform: targetingSimulator ? .visionOSSimulator : .visionOS,
+        platformVersion: platformVersion,
+        packageName: packageName,
+        productName: appConfiguration.product
+      ).mapError { error in
+        .failedToCopyResourceBundles(error)
+      }
+    }
+
+    let copyDynamicLibraries: () -> Result<Void, VisionOSBundlerError> = {
+      DynamicLibraryBundler.copyDynamicLibraries(
+        dependedOnBy: appExecutable,
+        to: appDynamicLibrariesDirectory,
+        productsDirectory: productsDirectory,
+        isXcodeBuild: false,
+        universal: false,
+        makeStandAlone: false
+      ).mapError { error in
+        .failedToCopyDynamicLibraries(error)
+      }
+    }
+
+    let embedProfile: () -> Result<Void, VisionOSBundlerError> = {
+      if let provisioningProfile = provisioningProfile {
+        return embedProvisioningProfile(provisioningProfile, in: appBundle)
+      } else {
+        return .success()
+      }
+    }
+
+    let codesign: () -> Result<Void, VisionOSBundlerError> = {
+      if let identity = codesigningIdentity {
+        return CodeSigner.signWithGeneratedEntitlements(
+          bundle: appBundle,
+          identityId: identity,
+          bundleIdentifier: appConfiguration.identifier
+        ).mapError { error in
+          .failedToCodesign(error)
+        }
+      } else {
+        return .success()
+      }
+    }
+
+    // TODO: Why is app icon creation disabled?
+    let bundleApp = flatten(
+      { createAppDirectoryStructure(at: outputDirectory, appName: appName) },
+      { copyExecutable(at: executableArtifact, to: appExecutable) },
+      {
+        createMetadataFiles(
+          at: appBundle,
+          appName: appName,
+          appConfiguration: appConfiguration,
+          visionOSVersion: platformVersion,
+          targetingSimulator: targetingSimulator
+        )
+      },
+      // { createAppIconIfPresent() },
+      { copyResourcesBundles() },
+      { copyDynamicLibraries() },
+      { embedProfile() },
+      { codesign() }
+    )
+
+    return bundleApp().mapError { (error: VisionOSBundlerError) -> Error in
+      error
+    }
+  }
+
+  // MARK: Private methods
+
+  /// Creates the directory structure for an app.
+  ///
+  /// Creates the following structure:
+  ///
+  /// - `AppName.app`
+  ///   - `Contents`
+  ///     - `MacOS`
+  ///     - `Resources`
+  ///     - `Libraries`
+  ///
+  /// If the app directory already exists, it is deleted before continuing.
+  ///
+  /// - Parameters:
+  ///   - outputDirectory: The directory to output the app to.
+  ///   - appName: The name of the app.
+  /// - Returns: A failure if directory creation fails.
+  private static func createAppDirectoryStructure(at outputDirectory: URL, appName: String) -> Result<Void, VisionOSBundlerError> {
+    log.info("Creating '\(appName).app'")
+    let fileManager = FileManager.default
+
+    let appBundleDirectory = outputDirectory.appendingPathComponent("\(appName).app")
+    let appDynamicLibrariesDirectory = appBundleDirectory.appendingPathComponent("Libraries")
+
+    do {
+      if fileManager.itemExists(at: appBundleDirectory, withType: .directory) {
+        try fileManager.removeItem(at: appBundleDirectory)
+      }
+      try fileManager.createDirectory(at: appBundleDirectory)
+      try fileManager.createDirectory(at: appDynamicLibrariesDirectory)
+      return .success()
+    } catch {
+      return .failure(.failedToCreateAppBundleDirectoryStructure(bundleDirectory: appBundleDirectory, error))
+    }
+  }
+
+  /// Copies the built executable into the app bundle.
+  /// - Parameters:
+  ///   - source: The location of the built executable.
+  ///   - destination: The target location of the built executable (the file not the directory).
+  /// - Returns: If an error occus, a failure is returned.
+  private static func copyExecutable(at source: URL, to destination: URL) -> Result<Void, VisionOSBundlerError> {
+    log.info("Copying executable")
+    do {
+      try FileManager.default.copyItem(at: source, to: destination)
+      return .success()
+    } catch {
+      return .failure(.failedToCopyExecutable(source: source, destination: destination, error))
+    }
+  }
+
+  /// Creates an app's `PkgInfo` and `Info.plist` files.
+  /// - Parameters:
+  ///   - outputDirectory: Should be the app's `Contents` directory.
+  ///   - appName: The app's name.
+  ///   - appConfiguration: The app's configuration.
+  ///   - visionOSVersion: The visionOS version to target.
+  ///   - targetingSimulator: If `true`, the files will be created for running in a simulator.
+  /// - Returns: If an error occurs, a failure is returned.
+  private static func createMetadataFiles(
+    at outputDirectory: URL,
+    appName: String,
+    appConfiguration: AppConfiguration,
+    visionOSVersion: String,
+    targetingSimulator: Bool
+  ) -> Result<Void, VisionOSBundlerError> {
+    log.info("Creating 'PkgInfo'")
+    let pkgInfoFile = outputDirectory.appendingPathComponent("PkgInfo")
+    do {
+      var pkgInfoBytes: [UInt8] = [0x41, 0x50, 0x50, 0x4C, 0x3F, 0x3F, 0x3F, 0x3F]
+      let pkgInfoData = Data(bytes: &pkgInfoBytes, count: pkgInfoBytes.count)
+      try pkgInfoData.write(to: pkgInfoFile)
+    } catch {
+      return .failure(.failedToCreatePkgInfo(file: pkgInfoFile, error))
+    }
+
+    log.info("Creating 'Info.plist'")
+    let infoPlistFile = outputDirectory.appendingPathComponent("Info.plist")
+    return PlistCreator.createAppInfoPlist(
+      at: infoPlistFile,
+      appName: appName,
+      configuration: appConfiguration,
+      platform: targetingSimulator ? .visionOSSimulator : .visionOS,
+      platformVersion: visionOSVersion
+    ).mapError { error in
+      .failedToCreateInfoPlist(error)
+    }
+  }
+
+  /// If given an `icns`, the `icns` gets copied to the output directory. If given a `png`, an `AppIcon.icns` is created from the `png`.
+  ///
+  /// The files are not validated any further than checking their file extensions.
+  /// - Parameters:
+  ///   - icon: The app's icon. Should be either an `icns` file or a 1024x1024 `png` with an alpha channel.
+  ///   - outputDirectory: Should be the app's `Resources` directory.
+  /// - Returns: If the png exists and there is an error while converting it to `icns`, a failure is returned.
+  ///            If the file is neither an `icns` or a `png`, a failure is also returned.
+  private static func createAppIcon(icon: URL, outputDirectory: URL) -> Result<Void, VisionOSBundlerError> {
+    // Copy `AppIcon.icns` if present
+    if icon.pathExtension == "icns" {
+      log.info("Copying '\(icon.lastPathComponent)'")
+      let destination = outputDirectory.appendingPathComponent("AppIcon.icns")
+      do {
+        try FileManager.default.copyItem(at: icon, to: destination)
+        return .success()
+      } catch {
+        return .failure(.failedToCopyICNS(source: icon, destination: destination, error))
+      }
+    } else if icon.pathExtension == "png" {
+      log.info("Creating 'AppIcon.icns' from '\(icon.lastPathComponent)'")
+      return IconSetCreator.createIcns(from: icon, outputDirectory: outputDirectory)
+        .mapError { error in
+          .failedToCreateIcon(error)
+        }
+    }
+
+    return .failure(.invalidAppIconFile(icon))
+  }
+
+  private static func embedProvisioningProfile(_ provisioningProfile: URL, in bundle: URL) -> Result<Void, VisionOSBundlerError> {
+    log.info("Embedding provisioning profile")
+
+    do {
+      try FileManager.default.copyItem(at: provisioningProfile, to: bundle.appendingPathComponent("embedded.mobileprovision"))
+    } catch {
+      return .failure(.failedToCopyProvisioningProfile(error))
+    }
+
+    return .success()
+  }
+}

--- a/Sources/swift-bundler/Bundler/VisionOSBundlerError.swift
+++ b/Sources/swift-bundler/Bundler/VisionOSBundlerError.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// An error returned by ``VisionOSBundler``.
+enum VisionOSBundlerError: LocalizedError {
+  case failedToBuild(product: String, SwiftPackageManagerError)
+  case failedToCreateAppBundleDirectoryStructure(bundleDirectory: URL, Error)
+  case failedToCreatePkgInfo(file: URL, Error)
+  case failedToCreateInfoPlist(PlistCreatorError)
+  case failedToCopyExecutable(source: URL, destination: URL, Error)
+  case failedToCreateIcon(IconSetCreatorError)
+  case failedToCopyICNS(source: URL, destination: URL, Error)
+  case failedToCopyResourceBundles(ResourceBundlerError)
+  case failedToCopyDynamicLibraries(DynamicLibraryBundlerError)
+  case failedToRunExecutable(ProcessError)
+  case invalidAppIconFile(URL)
+  case failedToCopyProvisioningProfile(Error)
+  case failedToCodesign(CodeSignerError)
+  case mustSpecifyBundleIdentifier
+  case failedToLoadManifest(SwiftPackageManagerError)
+  case failedToGetMinimumVisionOSVersion(manifest: URL)
+
+  var errorDescription: String? {
+    switch self {
+    case let .failedToBuild(product, swiftPackageManagerError):
+      return "Failed to build '\(product)': \(swiftPackageManagerError.localizedDescription)'"
+    case let .failedToCreateAppBundleDirectoryStructure(bundleDirectory, _):
+      return "Failed to create app bundle directory structure at '\(bundleDirectory)'"
+    case let .failedToCreatePkgInfo(file, _):
+      return "Failed to create 'PkgInfo' file at '\(file)'"
+    case let .failedToCreateInfoPlist(plistCreatorError):
+      return "Failed to create 'Info.plist': \(plistCreatorError.localizedDescription)"
+    case let .failedToCopyExecutable(source, destination, _):
+      return "Failed to copy executable from '\(source.relativePath)' to '\(destination.relativePath)'"
+    case let .failedToCreateIcon(iconSetCreatorError):
+      return "Failed to create app icon: \(iconSetCreatorError.localizedDescription)"
+    case let .failedToCopyICNS(source, destination, _):
+      return "Failed to copy 'icns' file from '\(source.relativePath)' to '\(destination.relativePath)'"
+    case let .failedToCopyResourceBundles(resourceBundlerError):
+      return "Failed to copy resource bundles: \(resourceBundlerError.localizedDescription)"
+    case let .failedToCopyDynamicLibraries(dynamicLibraryBundlerError):
+      return "Failed to copy dynamic libraries: \(dynamicLibraryBundlerError.localizedDescription)"
+    case let .failedToRunExecutable(processError):
+      return "Failed to run app executable: \(processError.localizedDescription)"
+    case let .invalidAppIconFile(file):
+      return "Invalid app icon file, must be 'png' or 'icns', got '\(file.relativePath)'"
+    case .failedToCopyProvisioningProfile:
+      return "Failed to copy provisioning profile to output bundle"
+    case let .failedToCodesign(error):
+      return error.localizedDescription
+    case .mustSpecifyBundleIdentifier:
+      return "Bundle identifier must be specified for visionOS apps"
+    case let .failedToLoadManifest(error):
+      return error.localizedDescription
+    case let .failedToGetMinimumVisionOSVersion(manifest):
+      return "To build for visionOS, please specify a visionOS deployment version in the platforms field of '\(manifest.relativePath)'"
+    }
+  }
+}

--- a/Sources/swift-bundler/Bundler/XcodeprojConverter/ExecutableTarget.swift
+++ b/Sources/swift-bundler/Bundler/XcodeprojConverter/ExecutableTarget.swift
@@ -19,6 +19,8 @@ extension XcodeprojConverter {
     var macOSDeploymentVersion: String?
     /// The target's minimum iOS version.
     var iOSDeploymentVersion: String?
+    /// The target's minimum visionOS version.
+    var visionOSDeploymentVersion: String?
     /// The target's `Info.plist` file.
     var infoPlist: URL?
   }

--- a/Sources/swift-bundler/Bundler/XcodeprojConverter/XcodeprojConverter.swift
+++ b/Sources/swift-bundler/Bundler/XcodeprojConverter/XcodeprojConverter.swift
@@ -505,7 +505,7 @@ enum XcodeprojConverter {
     let source = SourceFileSyntax {
       DeclSyntax("import PackageDescription")
         .withLeadingTrivia(Trivia(pieces: [
-          .lineComment("// swift-tools-version: 5.6"),
+          .lineComment("// swift-tools-version: 5.7"),
           .newlines(1)
         ]))
         .withTrailingTrivia(Trivia.newline)

--- a/Sources/swift-bundler/Bundler/XcodeprojConverter/XcodeprojConverter.swift
+++ b/Sources/swift-bundler/Bundler/XcodeprojConverter/XcodeprojConverter.swift
@@ -505,7 +505,7 @@ enum XcodeprojConverter {
     let source = SourceFileSyntax {
       DeclSyntax("import PackageDescription")
         .withLeadingTrivia(Trivia(pieces: [
-          .lineComment("// swift-tools-version: 5.7"),
+          .lineComment("// swift-tools-version: 5.6"),
           .newlines(1)
         ]))
         .withTrailingTrivia(Trivia.newline)

--- a/Sources/swift-bundler/Commands/AsyncCommand.swift
+++ b/Sources/swift-bundler/Commands/AsyncCommand.swift
@@ -1,5 +1,5 @@
 import Foundation
-import ArgumentParser
+import StackOtterArgParser
 
 /// An extension to the `AsyncParsableCommand` API with custom error handling.
 protocol AsyncCommand: AsyncParsableCommand {

--- a/Sources/swift-bundler/Commands/BundleArguments.swift
+++ b/Sources/swift-bundler/Commands/BundleArguments.swift
@@ -1,4 +1,4 @@
-import ArgumentParser
+import StackOtterArgParser
 import Foundation
 
 struct BundleArguments: ParsableArguments {
@@ -90,7 +90,7 @@ struct BundleArguments: ParsableArguments {
     /// A provisioing profile to use.
     @Option(
       name: .customLong("provisioning-profile"),
-      help: "The provisioning profile to embed in the app (only applicable to iOS).",
+      help: "The provisioning profile to embed in the app (only applicable to visionOS and iOS).",
       transform: URL.init(fileURLWithPath:))
     var provisioningProfile: URL?
 

--- a/Sources/swift-bundler/Commands/BundleCommand.swift
+++ b/Sources/swift-bundler/Commands/BundleCommand.swift
@@ -70,20 +70,11 @@ struct BundleCommand: AsyncCommand {
 
     // macOS-only arguments
     #if os(macOS)
-      if platform == .iOS,
+      if (platform == .iOS || platform == .visionOS),
         builtWithXcode || arguments.universal || !arguments.architectures.isEmpty
       {
         log.error(
-          "'--built-with-xcode', '--universal' and '--arch' are not compatible with '--platform iOS'"
-        )
-        return false
-      }
-
-      if platform == .visionOS,
-        builtWithXcode || arguments.universal || !arguments.architectures.isEmpty
-      {
-        log.error(
-          "'--built-with-xcode', '--universal' and '--arch' are not compatible with '--platform visionOS'"
+          "'--built-with-xcode', '--universal' and '--arch' are not compatible with '--platform \(platform.rawValue)'"
         )
         return false
       }
@@ -104,30 +95,12 @@ struct BundleCommand: AsyncCommand {
         return false
       }
 
-      if case .iOS = platform,
-        !arguments.shouldCodesign || arguments.identity == nil
-          || arguments.provisioningProfile == nil
-      {
-        log.error(
-          "Must specify `--identity`, `--codesign` and `--provisioning-profile` when building iOS app"
-        )
-        if arguments.identity == nil {
-          Output {
-            ""
-            Section("Tip: Listing available identities") {
-              ExampleCommand("swift bundler list-identities")
-            }
-          }.show()
-        }
-        return false
-      }
-
-      if case .visionOS = platform,
+      if platform == .iOS || platform == .visionOS,
          !arguments.shouldCodesign || arguments.identity == nil
          || arguments.provisioningProfile == nil
       {
         log.error(
-          "Must specify `--identity`, `--codesign` and `--provisioning-profile` when building visionOS app"
+          "Must specify `--identity`, `--codesign` and `--provisioning-profile` when '--platform \(platform.rawValue)'"
         )
         if arguments.identity == nil {
           Output {
@@ -146,9 +119,7 @@ struct BundleCommand: AsyncCommand {
       }
 
       switch platform {
-        case .iOS:
-          break
-        case .visionOS:
+        case .iOS, .visionOS:
           break
         default:
           if arguments.provisioningProfile != nil {
@@ -170,15 +141,9 @@ struct BundleCommand: AsyncCommand {
           ? [.arm64, .x86_64]
           : (!arguments.architectures.isEmpty
             ? arguments.architectures : [BuildArchitecture.current])
-      case .iOS:
+      case .iOS, .visionOS:
         architectures = [.arm64]
-      case .iOSSimulator:
-        architectures = [BuildArchitecture.current]
-      case .visionOS:
-        architectures = [.arm64]
-      case .visionOSSimulator:
-        architectures = [BuildArchitecture.current]
-      case .linux:
+      case .linux, .iOSSimulator, .visionOSSimulator:
         architectures = [BuildArchitecture.current]
     }
 

--- a/Sources/swift-bundler/Commands/Command.swift
+++ b/Sources/swift-bundler/Commands/Command.swift
@@ -1,5 +1,5 @@
 import Foundation
-import ArgumentParser
+import StackOtterArgParser
 
 /// An extension to the `ParsableCommand` API with custom error handling.
 protocol Command: ParsableCommand {

--- a/Sources/swift-bundler/Commands/ConvertCommand.swift
+++ b/Sources/swift-bundler/Commands/ConvertCommand.swift
@@ -1,7 +1,7 @@
 import Foundation
-import ArgumentParser
-import TOMLKit
+import StackOtterArgParser
 import SwiftXcodeProj
+import TOMLKit
 
 /// The command for converting xcodeprojs to Swift Bundler projects.
 struct ConvertCommand: Command {

--- a/Sources/swift-bundler/Commands/CreateCommand.swift
+++ b/Sources/swift-bundler/Commands/CreateCommand.swift
@@ -1,5 +1,5 @@
 import Foundation
-import ArgumentParser
+import StackOtterArgParser
 import Version
 
 /// The subcommand for creating new app packages from templates.

--- a/Sources/swift-bundler/Commands/GenerateXcodeSupportCommand.swift
+++ b/Sources/swift-bundler/Commands/GenerateXcodeSupportCommand.swift
@@ -1,5 +1,5 @@
 import Foundation
-import ArgumentParser
+import StackOtterArgParser
 
 /// The subcommand for generating Xcode related support files (i.e. Xcode schemes).
 struct GenerateXcodeSupportCommand: Command {

--- a/Sources/swift-bundler/Commands/ListIdentitiesCommand.swift
+++ b/Sources/swift-bundler/Commands/ListIdentitiesCommand.swift
@@ -1,5 +1,5 @@
 import Foundation
-import ArgumentParser
+import StackOtterArgParser
 
 /// The command for listing codesigning identities.
 struct ListIdentitiesCommand: Command {

--- a/Sources/swift-bundler/Commands/MigrateCommand.swift
+++ b/Sources/swift-bundler/Commands/MigrateCommand.swift
@@ -1,5 +1,5 @@
 import Foundation
-import ArgumentParser
+import StackOtterArgParser
 
 /// The command for listing codesigning identities.
 struct MigrateCommand: Command {

--- a/Sources/swift-bundler/Commands/Simulators/SimulatorsBootCommand.swift
+++ b/Sources/swift-bundler/Commands/Simulators/SimulatorsBootCommand.swift
@@ -1,11 +1,11 @@
 import Foundation
-import ArgumentParser
+import StackOtterArgParser
 
 /// The subcommand for booting simulators.
 struct SimulatorsBootCommand: Command {
   static var configuration = CommandConfiguration(
     commandName: "boot",
-    abstract: "Boot an iOS simulator."
+    abstract: "Boot an iOS or visionOS simulator."
   )
 
   /// The id or name of the simulator to start.

--- a/Sources/swift-bundler/Commands/Simulators/SimulatorsListCommand.swift
+++ b/Sources/swift-bundler/Commands/Simulators/SimulatorsListCommand.swift
@@ -1,11 +1,11 @@
 import Foundation
-import ArgumentParser
+import StackOtterArgParser
 
 /// The subcommand for listing available simulators.
 struct SimulatorsListCommand: Command {
   static var configuration = CommandConfiguration(
     commandName: "list",
-    abstract: "List available iOS simulators."
+    abstract: "List available iOS and visionOS simulators."
   )
 
   /// A search term or terms to filter by.

--- a/Sources/swift-bundler/Commands/SimulatorsCommand.swift
+++ b/Sources/swift-bundler/Commands/SimulatorsCommand.swift
@@ -1,5 +1,5 @@
 import Foundation
-import ArgumentParser
+import StackOtterArgParser
 
 /// The subcommand for managing and listing available simulators.
 struct SimulatorsCommand: ParsableCommand {

--- a/Sources/swift-bundler/Commands/Templates/TemplatesInfoCommand.swift
+++ b/Sources/swift-bundler/Commands/Templates/TemplatesInfoCommand.swift
@@ -1,6 +1,6 @@
 import Foundation
-import ArgumentParser
 import Rainbow
+import StackOtterArgParser
 
 /// The subcommand for getting info about a template.
 struct TemplatesInfoCommand: Command {

--- a/Sources/swift-bundler/Commands/Templates/TemplatesListCommand.swift
+++ b/Sources/swift-bundler/Commands/Templates/TemplatesListCommand.swift
@@ -1,5 +1,5 @@
 import Foundation
-import ArgumentParser
+import StackOtterArgParser
 
 /// The subcommand for listing available templates.
 struct TemplatesListCommand: Command {

--- a/Sources/swift-bundler/Commands/Templates/TemplatesUpdateCommand.swift
+++ b/Sources/swift-bundler/Commands/Templates/TemplatesUpdateCommand.swift
@@ -1,5 +1,5 @@
 import Foundation
-import ArgumentParser
+import StackOtterArgParser
 
 /// The subcommand for updating the default templates repository.
 struct TemplatesUpdateCommand: Command {

--- a/Sources/swift-bundler/Commands/TemplatesCommand.swift
+++ b/Sources/swift-bundler/Commands/TemplatesCommand.swift
@@ -1,5 +1,5 @@
 import Foundation
-import ArgumentParser
+import StackOtterArgParser
 
 /// The subcommand for managing and listing available package templates.
 struct TemplatesCommand: ParsableCommand {

--- a/Sources/swift-bundler/Extensions/Array.swift
+++ b/Sources/swift-bundler/Extensions/Array.swift
@@ -1,5 +1,5 @@
 import Foundation
-import ArgumentParser
+import StackOtterArgParser
 
 extension Array: ExpressibleByArgument where Element: ExpressibleByArgument {
   public var defaultValueDescription: String {

--- a/Sources/swift-bundler/SwiftBundler.swift
+++ b/Sources/swift-bundler/SwiftBundler.swift
@@ -1,5 +1,5 @@
 import Foundation
-import ArgumentParser
+import StackOtterArgParser
 import Version
 
 /// The root command of Swift Bundler.


### PR DESCRIPTION
This should roughly get **visionOS** most of the way there, albeit; quite a lazy approach I took here (using the same iOS simulator logic in many spots). There's probably a better way to do this in the long run.

Will need some additional double checking between the right usage of `.visionOS` vs `.xrOS` variants as I feel like I've officially confused myself now between the two! 😆 

> Note: there was some bashing between one of the dependencies and your fork of `ArgumentParser`, it appeared that a dependency was still looking for the Apple fork and not your fork -- as such, I simply took your fork and prefixed each of the library targets with ex: `ArgumentParser <-> StackOtterArgParser` to keep things split.