### PR TITLE
Update bundler for swift-argument-parser `v1.2.4`

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -59,7 +59,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Wabi-Studios/swift-arg-parser.git",
       "state" : {
-        "revision" : "b3fd0205d8a11f3bd97c3162864b737257509cd5",
+        "revision" : "764c0d39c5aff50aa2e33d8d056aa0835ef446a4",
         "version" : "1.2.4"
       }
     },

--- a/Package.resolved
+++ b/Package.resolved
@@ -55,12 +55,12 @@
       }
     },
     {
-      "identity" : "stackotter-parser",
+      "identity" : "swift-arg-parser",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Wabi-Studios/stackotter-parser.git",
+      "location" : "https://github.com/Wabi-Studios/swift-arg-parser.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "6639417d4da09cba76b2dea87362ce3ff1c157db"
+        "revision" : "b3fd0205d8a11f3bd97c3162864b737257509cd5",
+        "version" : "1.2.4"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     .executable(name: "swift-bundler", targets: ["swift-bundler"])
   ],
   dependencies: [
-    .package(url: "https://github.com/Wabi-Studios/stackotter-parser.git", branch: "main"),
+    .package(url: "https://github.com/Wabi-Studios/swift-arg-parser.git", from: "1.2.4"),
     .package(url: "https://github.com/apple/swift-log", from: "1.4.2"),
     .package(url: "https://github.com/pointfreeco/swift-parsing.git", from: "0.7.1"),
     .package(url: "https://github.com/LebJe/TOMLKit", branch: "main"),
@@ -27,7 +27,7 @@ let package = Package(
     .executableTarget(
       name: "swift-bundler",
       dependencies: [
-        .product(name: "StackOtterArgParser", package: "stackotter-parser"),
+        .product(name: "StackOtterArgParser", package: "swift-arg-parser"),
         .product(name: "Logging", package: "swift-log"),
         .product(name: "Parsing", package: "swift-parsing"),
         "TOMLKit",

--- a/Sources/swift-bundler/Commands/RunCommand.swift
+++ b/Sources/swift-bundler/Commands/RunCommand.swift
@@ -32,7 +32,7 @@ struct RunCommand: AsyncCommand {
 
   /// Command line arguments that get passed through to the app.
   @Argument(
-    parsing: .unconditionalRemaining,
+    parsing: .captureForPassthrough,
     help: "Command line arguments to pass through to the app.")
   var passThroughArguments: [String] = []
 


### PR DESCRIPTION
I had forgotten that the args parser was still pointed at [Wabi's fork](https://github.com/stackotter/swift-bundler/blob/05bef3265beef8124879d62bf7b3a18e41906488/Package.swift#L12).

You may pull the latest args parser in from [this PR](https://github.com/stackotter/swift-argument-parser/pull/1) which has your change on top. 

Optionally, you may switch the repo to point back to your fork if you do merge it, but I don't mind either way. Though, you may want to set it to the release tag at [`v1.2.4`](https://github.com/Wabi-Studios/swift-arg-parser/releases/tag/1.2.4).