### PR TITLE
Set TOMLKit package dependency to v0.5.5.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -185,7 +185,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/LebJe/TOMLKit",
       "state" : {
-        "branch" : "main",
+        "branch" : "0.5.5",
         "revision" : "404c4dd011743461bff12d00a5118d0ed59d630c"
       }
     },

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     .package(url: "https://github.com/stackotter/swift-arg-parser", from: "1.2.3"),
     .package(url: "https://github.com/apple/swift-log", from: "1.4.2"),
     .package(url: "https://github.com/pointfreeco/swift-parsing", from: "0.7.1"),
-    .package(url: "https://github.com/LebJe/TOMLKit", branch: "main"),
+    .package(url: "https://github.com/LebJe/TOMLKit", branch: "0.5.5"),
     .package(url: "https://github.com/onevcat/Rainbow", from: "3.0.0"),
     .package(url: "https://github.com/mxcl/Version.git", from: "2.0.0"),
     .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),


### PR DESCRIPTION
Fix for https://github.com/stackotter/swift-bundler/issues/34.