### PR TITLE
Create a swift bundler command line plugin.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -183,10 +183,10 @@
     {
       "identity" : "tomlkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/LebJe/TOMLKit",
+      "location" : "https://github.com/furby-tm/TOMLKit",
       "state" : {
-        "branch" : "0.5.5",
-        "revision" : "404c4dd011743461bff12d00a5118d0ed59d630c"
+        "revision" : "00aa7d07f61086a064666d67f46657da18faa5cb",
+        "version" : "0.5.6"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -185,7 +185,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/furby-tm/TOMLKit",
       "state" : {
-        "revision" : "00aa7d07f61086a064666d67f46657da18faa5cb",
+        "revision" : "f2b3e80a19c7fb3d42e3cfda98076cef8f0d1bd7",
         "version" : "0.5.6"
       }
     },

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,8 @@ let package = Package(
   name: "swift-bundler",
   platforms: [.macOS(.v11)],
   products: [
-    .executable(name: "swift-bundler", targets: ["swift-bundler"])
+    .executable(name: "swift-bundler", targets: ["swift-bundler"]),
+    .plugin(name: "SwiftBundlerCommandPlugin", targets: ["SwiftBundlerCommandPlugin"]),
   ],
   dependencies: [
     .package(url: "https://github.com/stackotter/swift-arg-parser", from: "1.2.3"),
@@ -58,6 +59,23 @@ let package = Package(
       name: "SwiftBundler",
       path: "Documentation",
       exclude: ["preview_docs.sh"]
+    ),
+
+    .plugin(
+      name: "SwiftBundlerCommandPlugin",
+      capability: .command(
+        intent: .custom(
+          verb: "bundler",
+          description: "Run a package as an app."
+        ),
+        permissions: [
+          .writeToPackageDirectory(
+            reason: "Creating an app bundle requires writing to the package directory.")
+        ]
+      ),
+      dependencies: [
+        .target(name: "swift-bundler")
+      ]
     ),
   ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     .package(url: "https://github.com/stackotter/swift-arg-parser", from: "1.2.3"),
     .package(url: "https://github.com/apple/swift-log", from: "1.4.2"),
     .package(url: "https://github.com/pointfreeco/swift-parsing", from: "0.7.1"),
-    .package(url: "https://github.com/LebJe/TOMLKit", branch: "0.5.5"),
+    .package(url: "https://github.com/furby-tm/TOMLKit", from: "0.5.6"),
     .package(url: "https://github.com/onevcat/Rainbow", from: "3.0.0"),
     .package(url: "https://github.com/mxcl/Version.git", from: "2.0.0"),
     .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),

--- a/Plugins/SwiftBundlerCommandPlugin/SwiftBundlerCommandPlugin.swift
+++ b/Plugins/SwiftBundlerCommandPlugin/SwiftBundlerCommandPlugin.swift
@@ -1,0 +1,45 @@
+import Foundation
+import PackagePlugin
+
+@main
+struct SwiftBundlerCommandPlugin: CommandPlugin {
+  /// This entry point is called when operating on a Swift package.
+  func performCommand(context: PluginContext, arguments: [String]) throws {
+    let bundler = try context.tool(named: "swift-bundler")
+
+    try run(command: bundler.path, with: arguments)
+  }
+}
+
+#if canImport(XcodeProjectPlugin)
+  import XcodeProjectPlugin
+
+  extension SwiftBundlerCommandPlugin: XcodeCommandPlugin {
+    /// This entry point is called when operating on an Xcode project.
+    func performCommand(context: XcodePluginContext, arguments: [String]) throws {
+      let bundler = try context.tool(named: "swift-bundler")
+
+      try run(command: bundler.path, with: arguments)
+    }
+  }
+#endif
+
+extension SwiftBundlerCommandPlugin {
+  /// Run a command with the given arguments.
+  func run(command: Path, with arguments: [String]) throws {
+    let exec = URL(fileURLWithPath: command.string)
+
+    let process = try Process.run(exec, arguments: arguments)
+    process.waitUntilExit()
+
+    // Check whether the subprocess invocation was successful.
+    if process.terminationReason == .exit,
+      process.terminationStatus == 0
+    {
+      print("SwiftBundlerCommandPlugin succesfully completed.")
+    } else {
+      let problem = "\(process.terminationReason):\(process.terminationStatus)"
+      Diagnostics.error("SwiftBundlerCommandPlugin failed: \(problem)")
+    }
+  }
+}

--- a/Plugins/SwiftBundlerCommandPlugin/SwiftBundlerCommandPlugin.swift
+++ b/Plugins/SwiftBundlerCommandPlugin/SwiftBundlerCommandPlugin.swift
@@ -11,19 +11,6 @@ struct SwiftBundlerCommandPlugin: CommandPlugin {
   }
 }
 
-#if canImport(XcodeProjectPlugin)
-  import XcodeProjectPlugin
-
-  extension SwiftBundlerCommandPlugin: XcodeCommandPlugin {
-    /// This entry point is called when operating on an Xcode project.
-    func performCommand(context: XcodePluginContext, arguments: [String]) throws {
-      let bundler = try context.tool(named: "swift-bundler")
-
-      try run(command: bundler.path, with: arguments)
-    }
-  }
-#endif
-
 extension SwiftBundlerCommandPlugin {
   /// Run a command with the given arguments.
   func run(command: Path, with arguments: [String]) throws {
@@ -36,7 +23,7 @@ extension SwiftBundlerCommandPlugin {
     if process.terminationReason == .exit,
       process.terminationStatus == 0
     {
-      print("SwiftBundlerCommandPlugin succesfully completed.")
+      print("SwiftBundlerCommandPlugin successfully completed.")
     } else {
       let problem = "\(process.terminationReason):\(process.terminationStatus)"
       Diagnostics.error("SwiftBundlerCommandPlugin failed: \(problem)")


### PR DESCRIPTION
This revision introduces a swift package plugin product for swift bundler, in the form of a command line plugin.

Usage:

```swift
$ swift package --disable-sandbox plugin bundler run -p macOS MetaversalDemo
```

```
Plugin ‘SwiftBundlerCommandPlugin’ wants permission to allow all network connections on all ports.
Stated reason: “Creating an app bundle may require network access.”.
Allow this plugin to allow all network connections on all ports? (yes/no) yes
Plugin ‘SwiftBundlerCommandPlugin’ wants permission to write to the package directory.
Stated reason: “Creating an app bundle requires writing to the package directory.”.
Allow this plugin to write to the package directory? (yes/no) yes
Building for debugging...
Build complete! (1.50s)
[0/1] Planning build
Building for debugging...
Build complete! (6.84s)
2023-12-07 21:26:05.151 MetaversalDemo[84817:99872459] WARNING: Secure coding is automatically enabled for restorable state! However, not on all supported macOS versions of this application. Opt-in to secure coding explicitly by implementing NSApplicationDelegate.applicationSupportsSecureRestorableState:.
Python v3.11
Python Version: 3.11.6 (main, Nov 16 2023, 00:01:35) [Clang 15.0.0 (clang-1500.1.0.1.1)]
Python Encoding: UTF-8
Python Path: ['/Users/furby/Wabi/MetaverseKit/.build/arm64-apple-macosx/debug/MetaversePythonFramework_PyBundle.bundle/Resources/python/3.11/macOS/python-stdlib', '/Users/furby/Wabi/MetaverseKit/.build/arm64-apple-macosx/debug/MetaversePythonFramework_PyBundle.bundle/Resources/python/3.11/macOS/python-stdlib/lib-dynload', '/Users/furby/Wabi/MetaverseKit/.build/arm64-apple-macosx/debug/MetaversePythonFramework_PyBundle.bundle/Resources/python/3.11/macOS/python-stdlib/lib/python311.zip', '/Users/furby/Wabi/MetaverseKit/.build/arm64-apple-macosx/debug/MetaversePythonFramework_PyBundle.bundle/Resources/python/3.11/macOS/python-stdlib/lib/python3.11', '/Users/furby/Wabi/MetaverseKit/.build/arm64-apple-macosx/debug/MetaversePythonFramework_PyBundle.bundle/Resources/python/3.11/macOS/python-stdlib/lib/python3.11/lib-dynload']
MetaversalDemo has launched.
view did load
info: Loading package manifest
info: Starting debug build
info: Bundling 'MetaversalDemo.app'
info: Creating 'MetaversalDemo.app'
info: Copying executable
info: Creating 'PkgInfo'
info: Creating 'Info.plist'
info: Compiling and copying resource bundle 'MetaversePythonFramework_PyBundle.bundle'
info: Copying dynamic libraries
info: Done in 9.58s. App bundle located at './.build/bundler/MetaversalDemo.app'
info: Running 'MetaversalDemo.app'
SwiftBundlerCommandPlugin succesfully completed.
```

