### PR TITLE
Fix Plurals in XCStrings

### DIFF
--- a/Sources/swift-bundler/Bundler/StringCatalogCompiler.swift
+++ b/Sources/swift-bundler/Bundler/StringCatalogCompiler.swift
@@ -317,7 +317,8 @@ enum StringCatalogCompiler {
   /// - Returns: The order of format specifiers in the string.
   private static func selectFormatSpecifierOrder(
     fileURL: URL,
-    from string: String) -> Result<[Int: (String, String)], StringCatalogCompilerError> {
+    from string: String
+  ) -> Result<[Int: (String, String)], StringCatalogCompilerError> {
     // Initialize the format specifier regex.
     let regex = getFormatValueTypeRegex()
     guard case let .success(regex) = regex else {

--- a/Sources/swift-bundler/Bundler/StringCatalogCompilerError.swift
+++ b/Sources/swift-bundler/Bundler/StringCatalogCompilerError.swift
@@ -1,6 +1,7 @@
 import Foundation
 /// An error returned by ``StringCatalogCompiler``.
 enum StringCatalogCompilerError: LocalizedError {
+  case failedToCreateFormatStringRegex(Error)
   case failedToEnumerateStringsCatalogs(URL, Error)
   case failedToDeleteStringsCatalog(URL, Error)
   case failedToCreateOutputDirectory(URL, Error)
@@ -13,6 +14,8 @@ enum StringCatalogCompilerError: LocalizedError {
 
   var errorDescription: String? {
     switch self {
+      case .failedToCreateFormatStringRegex(let error):
+        return "Failed to create format string regex with error '\(error)'"
       case .failedToEnumerateStringsCatalogs(let directory, _):
         return "Failed to enumerate strings catalogs in directory at '\(directory.relativePath)'"
       case .failedToDeleteStringsCatalog(let file, _):

--- a/Sources/swift-bundler/Bundler/StringCatalogCompilerError.swift
+++ b/Sources/swift-bundler/Bundler/StringCatalogCompilerError.swift
@@ -11,6 +11,7 @@ enum StringCatalogCompilerError: LocalizedError {
   case failedToEncodePlistStringsDictFile(URL, Error)
   case failedToWriteStringsFile(URL, Error)
   case failedToWriteStringsDictFile(URL, Error)
+  case invalidNonMatchingFormatString(URL, String)
 
   var errorDescription: String? {
     switch self {
@@ -34,6 +35,8 @@ enum StringCatalogCompilerError: LocalizedError {
         return "Failed to write strings file at '\(file.relativePath)'"
       case .failedToWriteStringsDictFile(let file, _):
         return "Failed to write strings dict file at '\(file.relativePath)'"
+      case .invalidNonMatchingFormatString(let file, let string):
+        return "Two or more format strings in the same string do not match in file '\(file.relativePath)' with string '\(string)'"
     }
   }
 }


### PR DESCRIPTION
There was a problem where plurals returned `(null)` when used. This fixes that by adding support for `NSStringFormatValueTypeKey`.

The code here is really crappy and botched, but it works.