### PR TITLE
Add entitlements file support for macOS builds

### DIFF
--- a/Sources/swift-bundler/Bundler/Bundler.swift
+++ b/Sources/swift-bundler/Bundler/Bundler.swift
@@ -12,6 +12,7 @@ protocol Bundler {
     universal: Bool,
     standAlone: Bool,
     codesigningIdentity: String?,
+    codesigningEntitlements: URL?,
     provisioningProfile: URL?,
     platformVersion: String,
     targetingSimulator: Bool

--- a/Sources/swift-bundler/Bundler/IOSBundler.swift
+++ b/Sources/swift-bundler/Bundler/IOSBundler.swift
@@ -32,6 +32,7 @@ enum IOSBundler: Bundler {
     universal: Bool,
     standAlone: Bool,
     codesigningIdentity: String?,
+    codesigningEntitlements: URL?,
     provisioningProfile: URL?,
     platformVersion: String,
     targetingSimulator: Bool

--- a/Sources/swift-bundler/Bundler/MacOSBundler.swift
+++ b/Sources/swift-bundler/Bundler/MacOSBundler.swift
@@ -32,6 +32,7 @@ enum MacOSBundler: Bundler {
     universal: Bool,
     standAlone: Bool,
     codesigningIdentity: String?,
+    codesigningEntitlements: URL?,
     provisioningProfile: URL?,
     platformVersion: String,
     targetingSimulator: Bool
@@ -83,7 +84,11 @@ enum MacOSBundler: Bundler {
 
     let sign: () -> Result<Void, MacOSBundlerError> = {
       if let identity = codesigningIdentity {
-        return CodeSigner.signAppBundle(bundle: appBundle, identityId: identity).mapError { error in
+        return CodeSigner.signAppBundle(
+          bundle: appBundle,
+          identityId: identity,
+          entitlements: codesigningEntitlements
+        ).mapError { error in
           return .failedToCodesign(error)
         }
       } else {

--- a/Sources/swift-bundler/Bundler/VisionOSBundler.swift
+++ b/Sources/swift-bundler/Bundler/VisionOSBundler.swift
@@ -32,6 +32,7 @@ enum VisionOSBundler: Bundler {
     universal: Bool,
     standAlone _: Bool,
     codesigningIdentity: String?,
+    codesigningEntitlements: URL?,
     provisioningProfile: URL?,
     platformVersion: String,
     targetingSimulator: Bool

--- a/Sources/swift-bundler/Commands/BundleArguments.swift
+++ b/Sources/swift-bundler/Commands/BundleArguments.swift
@@ -100,6 +100,13 @@ struct BundleArguments: ParsableArguments {
       help: "Codesign the application (use `--identity` to select the identity).")
     var shouldCodesign = false
 
+    /// A codesigning entitlements file to use.
+    @Option(
+      name: .customLong("entitlements"),
+      help: "The entitlements file to use for codesigning",
+      transform: URL.init(fileURLWithPath:))
+    var entitlements: URL?
+
     /// If `true`, a universal application will be created (arm64 and x86_64).
     @Flag(
       name: .shortAndLong,

--- a/Sources/swift-bundler/Commands/BundleCommand.swift
+++ b/Sources/swift-bundler/Commands/BundleCommand.swift
@@ -229,6 +229,7 @@ struct BundleCommand: AsyncCommand {
           universal: universal,
           standAlone: arguments.standAlone,
           codesigningIdentity: arguments.identity,
+          codesigningEntitlements: arguments.entitlements,
           provisioningProfile: arguments.provisioningProfile,
           platformVersion: platformVersion,
           targetingSimulator: arguments.platform.isSimulator


### PR DESCRIPTION
I'm working on a Swift application that uses the Virtualization framework. To meet the framework's requirements, it's necessary to include the `com.apple.security.virtualization` entitlement. Therefore, I've introduced the `--entitlements` flag that allows for specifying an entitlements file.