### PR TITLE
Support other platform sdks from generated xcode project.

### DIFF
--- a/Sources/swift-bundler/Bundler/SwiftPackageManager/AppleSDKPlatform.swift
+++ b/Sources/swift-bundler/Bundler/SwiftPackageManager/AppleSDKPlatform.swift
@@ -20,21 +20,21 @@ enum AppleSDKPlatform: String, CaseIterable {
   var platform: Platform {
     switch self {
       case .macosx:
-        .macOS
+        return .macOS
       case .iphoneos:
-        .iOS
+        return .iOS
       case .iphonesimulator:
-        .iOSSimulator
+        return .iOSSimulator
       case .xros:
-        .visionOS
+        return .visionOS
       case .xrsimulator:
-        .visionOSSimulator
+        return .visionOSSimulator
       case .appletvos:
-        .tvOS
+        return .tvOS
       case .appletvsimulator:
-        .tvOSSimulator
+        return .tvOSSimulator
       case .linux:
-        .linux
+        return .linux
     }
   }
 }

--- a/Sources/swift-bundler/Bundler/SwiftPackageManager/AppleSDKPlatform.swift
+++ b/Sources/swift-bundler/Bundler/SwiftPackageManager/AppleSDKPlatform.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// An apple SDK platform name to build for.
+enum AppleSDKPlatform: String, CaseIterable {
+  case macosx
+  case iphoneos
+  case iphonesimulator
+  case xros
+  case xrsimulator
+  case appletvos
+  case appletvsimulator
+  case linux
+
+  /// The platform's name.
+  var name: String {
+    rawValue
+  }
+
+  /// The Apple SDK's platform name (e.g. for `iphoneos` it's `iOS`).
+  var platform: Platform {
+    switch self {
+      case .macosx:
+        .macOS
+      case .iphoneos:
+        .iOS
+      case .iphonesimulator:
+        .iOSSimulator
+      case .xros:
+        .visionOS
+      case .xrsimulator:
+        .visionOSSimulator
+      case .appletvos:
+        .tvOS
+      case .appletvsimulator:
+        .tvOSSimulator
+      case .linux:
+        .linux
+    }
+  }
+}

--- a/Sources/swift-bundler/Bundler/SwiftPackageManager/Platform.swift
+++ b/Sources/swift-bundler/Bundler/SwiftPackageManager/Platform.swift
@@ -71,3 +71,50 @@ enum Platform: String, CaseIterable {
     #endif
   }
 }
+
+/// An apple SDK platform name to build for.
+enum AppleSDKPlatform: String, CaseIterable {
+  case macosx
+  case iphoneos
+  case iphonesimulator
+  case xros
+  case xrsimulator
+  case appletvos
+  case appletvsimulator
+  case linux
+
+  /// The platform's name.
+  var name: String {
+    return rawValue
+  }
+
+  /// The Apple SDK's platform name (e.g. for `iphoneos` it's `iOS`).
+  var platform: Platform {
+    switch self {
+      case .macosx:
+        return .macOS
+      case .iphoneos:
+        return .iOS
+      case .iphonesimulator:
+        return .iOSSimulator
+      case .xros:
+        return .visionOS
+      case .xrsimulator:
+        return .visionOSSimulator
+      case .appletvos:
+        return .tvOS
+      case .appletvsimulator:
+        return .tvOSSimulator
+      case .linux:
+        return .linux
+    }
+  }
+}
+
+extension Platform: Equatable
+{
+  public static func == (lhs: Platform, rhs: AppleSDKPlatform) -> Bool
+  {
+    lhs.rawValue == rhs.rawValue
+  }
+}

--- a/Sources/swift-bundler/Bundler/SwiftPackageManager/Platform.swift
+++ b/Sources/swift-bundler/Bundler/SwiftPackageManager/Platform.swift
@@ -72,45 +72,6 @@ enum Platform: String, CaseIterable {
   }
 }
 
-/// An apple SDK platform name to build for.
-enum AppleSDKPlatform: String, CaseIterable {
-  case macosx
-  case iphoneos
-  case iphonesimulator
-  case xros
-  case xrsimulator
-  case appletvos
-  case appletvsimulator
-  case linux
-
-  /// The platform's name.
-  var name: String {
-    return rawValue
-  }
-
-  /// The Apple SDK's platform name (e.g. for `iphoneos` it's `iOS`).
-  var platform: Platform {
-    switch self {
-      case .macosx:
-        return .macOS
-      case .iphoneos:
-        return .iOS
-      case .iphonesimulator:
-        return .iOSSimulator
-      case .xros:
-        return .visionOS
-      case .xrsimulator:
-        return .visionOSSimulator
-      case .appletvos:
-        return .tvOS
-      case .appletvsimulator:
-        return .tvOSSimulator
-      case .linux:
-        return .linux
-    }
-  }
-}
-
 extension Platform: Equatable {
   public static func ==(lhs: Platform, rhs: AppleSDKPlatform) -> Bool {
     lhs == rhs.platform

--- a/Sources/swift-bundler/Bundler/SwiftPackageManager/Platform.swift
+++ b/Sources/swift-bundler/Bundler/SwiftPackageManager/Platform.swift
@@ -111,10 +111,8 @@ enum AppleSDKPlatform: String, CaseIterable {
   }
 }
 
-extension Platform: Equatable
-{
-  public static func == (lhs: Platform, rhs: AppleSDKPlatform) -> Bool
-  {
-    lhs.rawValue == rhs.rawValue
+extension Platform: Equatable {
+  public static func ==(lhs: Platform, rhs: AppleSDKPlatform) -> Bool {
+    lhs == rhs.platform
   }
 }

--- a/Sources/swift-bundler/Bundler/XcodeSupportGenerator.swift
+++ b/Sources/swift-bundler/Bundler/XcodeSupportGenerator.swift
@@ -115,7 +115,7 @@ enum XcodeSupportGenerator {
       "export PATH=`zsh --login -c '[ -f /etc/zshrc ] && . /etc/zshrc; [ -f ~/.zshrc ] && . ~/.zshrc; echo $PATH'`"
     let command = "swift-bundler bundle"
     let arguments =
-      "\(app) -d \(packagePath) --products-directory ${BUILT_PRODUCTS_DIR} -o '\(escapedOutputPath)' --skip-build --built-with-xcode"
+      "\(app) -d \(packagePath) --products-directory ${BUILT_PRODUCTS_DIR} -o '\(escapedOutputPath)' --skip-build --built-with-xcode --platform ${TARGET_DEVICE_PLATFORM_NAME}"
     let createBundle = "\(fixPath); \(command) \(arguments)"
       .replacingOccurrences(of: "&", with: "&amp;")
 

--- a/Sources/swift-bundler/Commands/BundleArguments.swift
+++ b/Sources/swift-bundler/Commands/BundleArguments.swift
@@ -74,8 +74,7 @@ struct BundleArguments: ParsableArguments {
     }(),
     transform: { string in
       // also support getting a platform by its apple sdk equivalent.
-      if let appleSDK = AppleSDKPlatform(rawValue: string)
-      {
+      if let appleSDK = AppleSDKPlatform(rawValue: string) {
         return appleSDK.platform
       }
 

--- a/Sources/swift-bundler/Commands/BundleArguments.swift
+++ b/Sources/swift-bundler/Commands/BundleArguments.swift
@@ -73,10 +73,10 @@ struct BundleArguments: ParsableArguments {
       return "The platform to build for \(possibleValues). (default: macOS)"
     }(),
     transform: { string in
-      // also support getting a platform it's apple sdk equivalent.
-      if let applePlatform = AppleSDKPlatform(rawValue: string)
+      // also support getting a platform by its apple sdk equivalent.
+      if let appleSDK = AppleSDKPlatform(rawValue: string)
       {
-        return applePlatform.platform
+        return appleSDK.platform
       }
 
       guard let platform = Platform(rawValue: string) else {

--- a/Sources/swift-bundler/Commands/BundleArguments.swift
+++ b/Sources/swift-bundler/Commands/BundleArguments.swift
@@ -73,6 +73,12 @@ struct BundleArguments: ParsableArguments {
       return "The platform to build for \(possibleValues). (default: macOS)"
     }(),
     transform: { string in
+      // also support getting a platform it's apple sdk equivalent.
+      if let applePlatform = AppleSDKPlatform(rawValue: string)
+      {
+        return applePlatform.platform
+      }
+
       guard let platform = Platform(rawValue: string) else {
         throw CLIError.invalidPlatform(string)
       }


### PR DESCRIPTION
* Namely, this supports the ability for a user to select **iOS**, **visionOS**, and **tvOS** devices from Xcode's **run destinations** with Xcode projects generated via `swift bundler generate-xcode-project`, which would otherwise cause the app to be built for the wrong device, **macOS**, and be unable to be launched from the user's selected **run destination**.
* This also allows calls to swift bundler's `--platform` switch to be synonymously called with apple platform sdk equivalents.

As an example:
```swift
swift bundler run --platform xros
```

Is now also exactly equivalent to:
```swift
swift bundler run --platform visionOS
```