### PR TITLE
Fix loading package manifest

### DIFF
--- a/Sources/swift-bundler/Bundler/SwiftPackageManager/SwiftPackageManager.swift
+++ b/Sources/swift-bundler/Bundler/SwiftPackageManager/SwiftPackageManager.swift
@@ -440,7 +440,7 @@ enum SwiftPackageManager {
   ) -> Result<PackageManifest, SwiftPackageManagerError> {
     let process = Process.create(
       "swift",
-      arguments: ["package", "describe", "--type", "json"]
+      arguments: ["package", "--package-path", "\(packageDirectory.path)", "describe", "--type", "json"]
     )
 
     return process.getOutput().mapError { error in


### PR DESCRIPTION
This PR fixes a crash when running `swift-bundler` `bundle` or `run` with added `-d` or `--directory` argument pointing to a package-path other than the current directory.

`swift-bundler bundle --directory <path_to_package_root> <target_name>` produces error:

```shell
info: Loading package manifest
error: Failed to run '/usr/bin/env swift package describe --type json': The process returned a non-zero exit status (1)
error: Could not find Package.swift in this directory or any of its parent directories.


info: Use -v to get more error details
Program ended with exit code: 1
```

Solution is to include the already provided `packageDirectory` argument in `loadPackageManifest` ([SwiftPackageManager.swift:438](https://github.com/stackotter/swift-bundler/blob/main/Sources/swift-bundler/Bundler/SwiftPackageManager/SwiftPackageManager.swift#L438)) to the `swift package` command invocation.