### PR TITLE
Support wildcard provisioning profiles

### DIFF
--- a/Sources/swift-bundler/Bundler/ProvisioningProfileManager/ProvisioningProfile.swift
+++ b/Sources/swift-bundler/Bundler/ProvisioningProfileManager/ProvisioningProfile.swift
@@ -59,7 +59,7 @@ extension ProvisioningProfile: Decodable {
     self.init(
       teamIdentifierArray: try container.decode([String].self, forKey: .teamIdentifierArray),
       expirationDate: try container.decode(Date.self, forKey: .expirationDate),
-      provisionedDevices: try container.decode([String].self, forKey: .provisionedDevices),
+      provisionedDevices: try container.decodeIfPresent([String].self, forKey: .provisionedDevices) ?? [],
       platforms: try container.decode([String].self, forKey: .platforms),
       appId: try container.decode(String.self, forKey: .appId),
       entitlements: try container.decode(Entitlements.self, forKey: .entitlements),


### PR DESCRIPTION
Mobile provisioning profiles can be created such that they support multiple devices through a wildcard.
This has the consequence that the `ProvisionedDevices` property is not present.

This PR fixes failed decoding by allowing for a missing `ProvisionedDevices` property.