### PR TITLE
Add Windows CI & CI badges

### DIFF
--- a/.github/workflows/swift-linux.yml
+++ b/.github/workflows/swift-linux.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    container:
+      image: swift:5.10.0
+    
     steps:
       - name: Swift version
         run: swift --version

--- a/.github/workflows/swift-macos.yml
+++ b/.github/workflows/swift-macos.yml
@@ -7,10 +7,12 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
-      - name: List Xcode versions
-        run: ls /Applications | grep Xcode
+      - name: Setup Xcode version
+        uses: maxim-lobanov/setup-xcode@v1.6.0
+        with:
+          xcode-version: '15.4' # contains Swift 5.10.0
 
       - name: Swift version
         run: swift --version

--- a/.github/workflows/swift-windows.yml
+++ b/.github/workflows/swift-windows.yml
@@ -5,18 +5,34 @@ on:
   pull_request:
   workflow_dispatch:
 
+defaults:
+  run: # Use powershell because bash is not supported: https://github.com/compnerd/gha-setup-swift/issues/18#issuecomment-1705524890
+    shell: pwsh
+
 jobs:
-  windows:
-    runs-on: windows-latest
+  build:
+    runs-on: windows-2019 # Windows SDK lower than 10.0.26100 is needed until https://github.com/swiftlang/swift/pull/79751 released!
     steps:
+      
+      - name: Setup VS Dev Environment
+        uses: seanmiddleditch/gha-setup-vsdevenv@v5
+
       - name: Setup
-        uses: compnerd/gha-setup-swift@v0.3.0
+        uses: compnerd/gha-setup-swift@v0.2.3
         with:
-          branch: swift-6.0-release
-          tag: 6.0-RELEASE
+          branch: swift-5.10.0-release
+          tag: 5.10.0-RELEASE
 
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Swift version
+        run: swift --version
+
       - name: Build
-        run: swift build
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = "Stop"
+          $PSNativeCommandUseErrorActionPreference = $true
+
+          swift build --product swift-bundler

--- a/.github/workflows/swift-windows.yml
+++ b/.github/workflows/swift-windows.yml
@@ -1,0 +1,22 @@
+name: Build Windows
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  windows:
+    runs-on: windows-latest
+    steps:
+      - name: Setup
+        uses: compnerd/gha-setup-swift@v0.3.0
+        with:
+          branch: swift-6.0-release
+          tag: 6.0-RELEASE
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build
+        run: swift build

--- a/.github/workflows/swift-windows.yml
+++ b/.github/workflows/swift-windows.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Setup
         uses: compnerd/gha-setup-swift@v0.2.3
         with:
-          branch: swift-5.10.0-release
-          tag: 5.10.0-RELEASE
+          branch: swift-5.10-release
+          tag: 5.10-RELEASE
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@
 
 <p align="center">
   <a href="https://swiftpackageindex.com/stackotter/swift-bundler"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fstackotter%2Fswift-bundler%2Fbadge%3Ftype%3Dswift-versions"></a>
-  <a href="https://discord.gg/6mUFu3KtAn"><img src="https://img.shields.io/discord/949626773295988746?color=6A7EC2&label=discord&logo=discord&logoColor=ffffff"></a>
+  <a href="https://github.com/stackotter/swift-bundler/actions/workflows/swift-macos.yml" alt="Build macOS"><img src="https://github.com/stackotter/swift-bundler/actions/workflows/swift-macos.yml/badge.svg"></a>
+  <a href="https://github.com/stackotter/swift-bundler/actions/workflows/swift-linux.yml" alt="Build Linux"><img src="https://github.com/stackotter/swift-bundler/actions/workflows/swift-linux.yml/badge.svg"></a>
+  <a href="https://github.com/stackotter/swift-bundler/actions/workflows/swift-windows.yml" alt="Build Linux"><img src="https://github.com/stackotter/swift-bundler/actions/workflows/swift-windows.yml/badge.svg"></a>
+  <a href="https://discord.gg/6mUFu3KtAn"><img src="https://img.shields.io/discord/949626773295988746?color=6A7EC2&label=discord&logo=discord&logoColor=ffffff"></a> 
 </p>
 
 <p align="center">

--- a/Sources/swift-bundler/Bundler/ProjectBuilder.swift
+++ b/Sources/swift-bundler/Bundler/ProjectBuilder.swift
@@ -1,7 +1,6 @@
 import AsyncCollections
 import Foundation
 import SwiftBundlerBuilders
-import SystemPackage
 import Version
 
 enum ProjectBuilder {


### PR DESCRIPTION
- Adds Windows CI workflow so that swift-bundler is for sure running on Windows as well
- Adds CI badges to README.md
- Sets CI Swift version to 5.10