### PR TITLE
Move back to PureSwift/Socket

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -39,10 +39,10 @@
     {
       "identity" : "socket",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/stackotter/Socket",
+      "location" : "https://github.com/PureSwift/Socket",
       "state" : {
-        "revision" : "9945adfb7b2b089b1f9963db31544f604d260293",
-        "version" : "0.3.3"
+        "revision" : "253aef83213691b705dfeec8e20bfd7a72219fec",
+        "version" : "0.4.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
     .package(url: "https://github.com/yonaskolb/XcodeGen", from: "2.42.0"),
     .package(url: "https://github.com/swiftlang/swift-syntax", from: "600.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-overture", from: "0.5.0"),
-    .package(url: "https://github.com/stackotter/Socket", from: "0.3.3"),
+    .package(url: "https://github.com/PureSwift/Socket", from: "0.4.0"),
     .package(url: "https://github.com/jpsim/Yams", from: "5.1.2"),
     .package(url: "https://github.com/kylef/PathKit", from: "1.0.1"),
     .package(url: "https://github.com/apple/swift-certificates", from: "1.7.0"),


### PR DESCRIPTION
contains necessary fixes for Swift 6.1+ (at least on Linux)