### PR TITLE
Switch from PureSwift/Socket fork to FlyingSocks (better maintained)

### DIFF
--- a/.github/workflows/swift-linux.yml
+++ b/.github/workflows/swift-linux.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: swift:5.10.0
+      image: swift:6.0.0
     
     steps:
       - name: Swift version

--- a/.github/workflows/swift-windows.yml
+++ b/.github/workflows/swift-windows.yml
@@ -10,8 +10,8 @@ defaults:
     shell: pwsh
 
 jobs:
-  runs-on: windows
   build:
+    runs-on: windows
     timeout-minutes: 30
     steps:
       

--- a/.github/workflows/swift-windows.yml
+++ b/.github/workflows/swift-windows.yml
@@ -11,7 +11,7 @@ defaults:
 
 jobs:
   build:
-    runs-on: windows
+    runs-on: windows-latest
     timeout-minutes: 30
     steps:
       

--- a/.github/workflows/swift-windows.yml
+++ b/.github/workflows/swift-windows.yml
@@ -11,7 +11,6 @@ defaults:
 
 jobs:
   build:
-    runs-on: windows-2019 # Windows SDK lower than 10.0.26100 is needed until https://github.com/swiftlang/swift/pull/79751 released!
     timeout-minutes: 30
     steps:
       
@@ -21,8 +20,8 @@ jobs:
       - name: Setup
         uses: compnerd/gha-setup-swift@v0.2.3
         with:
-          branch: swift-5.10-release
-          tag: 5.10-RELEASE
+          branch: swift-6.1-release
+          tag: 6.1-RELEASE
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/swift-windows.yml
+++ b/.github/workflows/swift-windows.yml
@@ -10,6 +10,7 @@ defaults:
     shell: pwsh
 
 jobs:
+  runs-on: windows
   build:
     timeout-minutes: 30
     steps:

--- a/Package.resolved
+++ b/Package.resolved
@@ -28,6 +28,15 @@
       }
     },
     {
+      "identity" : "flyingfox",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swhitty/FlyingFox",
+      "state" : {
+        "revision" : "3ad076e081749cef043e25ac01719a503b772113",
+        "version" : "0.22.0"
+      }
+    },
+    {
       "identity" : "jsonutilities",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/yonaskolb/JSONUtilities.git",
@@ -52,15 +61,6 @@
       "state" : {
         "revision" : "0c627a4f8a39ef37eadec1ceec02e4a7f55561ac",
         "version" : "4.1.0"
-      }
-    },
-    {
-      "identity" : "socket",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/stackotter/Socket",
-      "state" : {
-        "revision" : "9945adfb7b2b089b1f9963db31544f604d260293",
-        "version" : "0.3.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
     .package(url: "https://github.com/yonaskolb/XcodeGen", from: "2.42.0"),
     .package(url: "https://github.com/swiftlang/swift-syntax", from: "600.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-overture", from: "0.5.0"),
-    .package(url: "https://github.com/stackotter/Socket", from: "0.3.3"),
+    .package(url: "https://github.com/swhitty/FlyingFox", from: "0.22.0"),
     .package(url: "https://github.com/jpsim/Yams", from: "5.1.2"),
     .package(url: "https://github.com/kylef/PathKit", from: "1.0.1"),
     .package(url: "https://github.com/apple/swift-certificates", from: "1.7.0"),
@@ -90,8 +90,8 @@ let package = Package(
 
         // Hot reloading related dependencies
         .product(
-          name: "Socket",
-          package: "Socket",
+          name: "FlyingSocks",
+          package: "FlyingFox",
           condition: .when(platforms: [.macOS, .linux])
         ),
         .target(
@@ -120,7 +120,7 @@ let package = Package(
     .target(
       name: "SwiftBundlerRuntime",
       dependencies: [
-        "Socket",
+        .product(name: "FlyingSocks", package: "FlyingFox"),
         "HotReloadingProtocol",
       ]
     ),
@@ -139,7 +139,7 @@ let package = Package(
     .target(
       name: "HotReloadingProtocol",
       dependencies: [
-        "Socket"
+        .product(name: "FlyingSocks", package: "FlyingFox")
       ]
     ),
 
@@ -166,7 +166,7 @@ let package = Package(
 
     .testTarget(
       name: "SwiftBundlerTests",
-      dependencies: ["swift-bundler"]
+      dependencies: ["SwiftBundler"]
     ),
 
     .plugin(

--- a/Sources/HotReloadingProtocol/Socket+Stream.swift
+++ b/Sources/HotReloadingProtocol/Socket+Stream.swift
@@ -1,14 +1,11 @@
+import FlyingSocks
 import Foundation
-import Socket
 
-extension Socket: ReadableStream {
+extension AsyncSocket: ReadableStream {
   public func read(exactly count: Int) async throws -> Data {
-    try await read(count)
+    let bytes = try await read(atMost: count)
+    return Data(bytes)
   }
 }
 
-extension Socket: WritableStream {
-  public func write(_ data: Data) async throws {
-    try await sendMessage(data)
-  }
-}
+extension AsyncSocket: WritableStream {}

--- a/Sources/SwiftBundler/Bundler/HotReloadingServer.swift
+++ b/Sources/SwiftBundler/Bundler/HotReloadingServer.swift
@@ -1,169 +1,171 @@
-import FileSystemWatcher
-import FlyingSocks
-import Foundation
-import HotReloadingProtocol
+#if SUPPORT_HOT_RELOADING
+  import Foundation
+  import FileSystemWatcher
+  import FlyingSocks
+  import HotReloadingProtocol
 
-#if canImport(Darwin)
-  import Darwin
-#elseif canImport(Glibc)
-  import Glibc
-#elseif canImport(WinSDK)
-  import WinSDK.WinSock2
-#endif
+  #if canImport(Darwin)
+    import Darwin
+  #elseif canImport(Glibc)
+    import Glibc
+  #elseif canImport(WinSDK)
+    import WinSDK.WinSock2
+  #endif
 
-struct HotReloadingServer {
-  let port: UInt16
-  let socket: AsyncSocket
+  struct HotReloadingServer {
+    let port: UInt16
+    let socket: AsyncSocket
 
-  enum Error: LocalizedError {
-    case failedToSendPing(Swift.Error)
-    case expectedPong(Packet)
-    case addrInUse
-    case failedToCreateSocket(Swift.Error)
-    case failedToAcceptConnection(Swift.Error)
-    case failedToWatchPackage(Swift.Error)
+    enum Error: LocalizedError {
+      case failedToSendPing(Swift.Error)
+      case expectedPong(Packet)
+      case addrInUse
+      case failedToCreateSocket(Swift.Error)
+      case failedToAcceptConnection(Swift.Error)
+      case failedToWatchPackage(Swift.Error)
 
-    var errorDescription: String? {
-      switch self {
-        case .failedToSendPing(let error):
-          return "Failed to send ping: \(error.localizedDescription)"
-        case .expectedPong(let response):
-          return "Expected pong, got '\(response)'"
-        case .addrInUse:
-          return "Failed to create socket: Address in use"
-        case .failedToCreateSocket(let error):
-          return "Failed to create socket: \(error.localizedDescription)"
-        case .failedToAcceptConnection(let error):
-          return "Failed to accept connection: \(error.localizedDescription)"
-        case .failedToWatchPackage(let error):
-          return "Failed to watch package: \(error.localizedDescription)"
+      var errorDescription: String? {
+        switch self {
+          case .failedToSendPing(let error):
+            return "Failed to send ping: \(error.localizedDescription)"
+          case .expectedPong(let response):
+            return "Expected pong, got '\(response)'"
+          case .addrInUse:
+            return "Failed to create socket: Address in use"
+          case .failedToCreateSocket(let error):
+            return "Failed to create socket: \(error.localizedDescription)"
+          case .failedToAcceptConnection(let error):
+            return "Failed to accept connection: \(error.localizedDescription)"
+          case .failedToWatchPackage(let error):
+            return "Failed to watch package: \(error.localizedDescription)"
+        }
       }
     }
-  }
 
-  static func create(portHint: UInt16 = 7331) async -> Result<Self, Error> {
-    var port = portHint
+    static func create(portHint: UInt16 = 7331) async -> Result<Self, Error> {
+      var port = portHint
 
-    // Attempt to create socket and if the address is already in use, retry with
-    // higher and higher ports until socket creation fails for another reason or
-    // a free address is found.
-    while true {
-      switch await Self.createSocket(port: port) {
-        case .success(let socket):
-          return .success(Self(port: port, socket: socket))
-        case .failure(.addrInUse):
-          port += 1
+      // Attempt to create socket and if the address is already in use, retry with
+      // higher and higher ports until socket creation fails for another reason or
+      // a free address is found.
+      while true {
+        switch await Self.createSocket(port: port) {
+          case .success(let socket):
+            return .success(Self(port: port, socket: socket))
+          case .failure(.addrInUse):
+            port += 1
+          case .failure(let error):
+            return .failure(error)
+        }
+      }
+    }
+
+    static func createSocket(port: UInt16) async -> Result<AsyncSocket, Error> {
+      do {
+        // FlyingSocks relies on type inference tricks to hide away sockaddr_in,
+        // but using them here breaks our Linux CI, so just spell it out and hope
+        // FlyingSocks doesn't break this if/when they introduce more Swifty
+        // SocketAddress wrappers (which would be very welcome regardless).
+        let address = try sockaddr_in.inet(ip4: "127.0.0.1", port: port)
+        let socket = try Socket(domain: Int32(type(of: address).family))
+        try socket.bind(to: address)
+        try socket.listen()
+
+        let pool = SocketPool.make()
+        try await pool.prepare()
+        Task {
+          try await pool.run()
+        }
+
+        let asyncSocket = try AsyncSocket(
+          socket: socket,
+          pool: pool
+        )
+        return .success(asyncSocket)
+      } catch let error as SocketError {
+        let addrInUse: Int32
+        #if canImport(Darwin) || canImport(Glibc)
+          addrInUse = EADDRINUSE
+        #elseif canImport(WinSDK)
+          addrInUse = WSAEADDRINUSE
+        #endif
+
+        guard
+          case let .failed(_, errno, _) = error,
+          errno == addrInUse
+        else {
+          return .failure(.failedToCreateSocket(error))
+        }
+
+        return .failure(.addrInUse)
+      } catch {
+        return .failure(.failedToCreateSocket(error))
+      }
+    }
+
+    func start(
+      product: String,
+      buildContext: SwiftPackageManager.BuildContext
+    ) async -> Result<(), Error> {
+      var connection: AsyncSocket
+      switch await accept() {
+        case .success(let value):
+          connection = value
         case .failure(let error):
           return .failure(error)
       }
-    }
-  }
 
-  static func createSocket(port: UInt16) async -> Result<AsyncSocket, Error> {
-    do {
-      // FlyingSocks relies on type inference tricks to hide away sockaddr_in,
-      // but using them here breaks our Linux CI, so just spell it out and hope
-      // FlyingSocks doesn't break this if/when they introduce more Swifty
-      // SocketAddress wrappers (which would be very welcome regardless).
-      let address = try sockaddr_in.inet(ip4: "127.0.0.1", port: port)
-      let socket = try Socket(domain: Int32(type(of: address).family))
-      try socket.bind(to: address)
-      try socket.listen()
+      log.debug("Received connection from runtime")
 
-      let pool = SocketPool.make()
-      try await pool.prepare()
-      Task {
-        try await pool.run()
-      }
+      return await Self.handshake(&connection).andThen { _ in
+        log.debug("Handshake succeeded")
+        let sourcesDirectory = buildContext.genericContext.projectDirectory / "Sources"
+        return await Result {
+          try await FileSystemWatcher.watch(
+            paths: [sourcesDirectory.path],
+            with: {
+              log.info("Building 'lib\(product).dylib'")
+              let connection = connection
+              Task {
+                do {
+                  var connection = connection
+                  let dylibFile = try await SwiftPackageManager.buildExecutableAsDylib(
+                    product: product,
+                    buildContext: buildContext
+                  ).unwrap()
+                  log.info("Successfully built dylib")
 
-      let asyncSocket = try AsyncSocket(
-        socket: socket,
-        pool: pool
-      )
-      return .success(asyncSocket)
-    } catch let error as SocketError {
-      let addrInUse: Int32
-      #if canImport(Darwin) || canImport(Glibc)
-        addrInUse = EADDRINUSE
-      #elseif canImport(WinSDK)
-        addrInUse = WSAEADDRINUSE
-      #endif
-
-      guard
-        case let .failed(_, errno, _) = error,
-        errno == addrInUse
-      else {
-        return .failure(.failedToCreateSocket(error))
-      }
-
-      return .failure(.addrInUse)
-    } catch {
-      return .failure(.failedToCreateSocket(error))
-    }
-  }
-
-  func start(
-    product: String,
-    buildContext: SwiftPackageManager.BuildContext
-  ) async -> Result<(), Error> {
-    var connection: AsyncSocket
-    switch await accept() {
-      case .success(let value):
-        connection = value
-      case .failure(let error):
-        return .failure(error)
-    }
-
-    log.debug("Received connection from runtime")
-
-    return await Self.handshake(&connection).andThen { _ in
-      log.debug("Handshake succeeded")
-      let sourcesDirectory = buildContext.genericContext.projectDirectory / "Sources"
-      return await Result {
-        try await FileSystemWatcher.watch(
-          paths: [sourcesDirectory.path],
-          with: {
-            log.info("Building 'lib\(product).dylib'")
-            let connection = connection
-            Task {
-              do {
-                var connection = connection
-                let dylibFile = try await SwiftPackageManager.buildExecutableAsDylib(
-                  product: product,
-                  buildContext: buildContext
-                ).unwrap()
-                log.info("Successfully built dylib")
-
-                try await Packet.reloadDylib(path: dylibFile).write(to: &connection)
-              } catch {
-                log.error("Hot reloading failed: \(error.localizedDescription)")
+                  try await Packet.reloadDylib(path: dylibFile).write(to: &connection)
+                } catch {
+                  log.error("Hot reloading failed: \(error.localizedDescription)")
+                }
               }
+            },
+            errorHandler: { error in
+              log.error("Hot reloading failed: \(error.localizedDescription)")
             }
-          },
-          errorHandler: { error in
-            log.error("Hot reloading failed: \(error.localizedDescription)")
-          }
-        )
+          )
+        }
+        .mapError(Error.failedToWatchPackage)
       }
-      .mapError(Error.failedToWatchPackage)
+    }
+
+    func accept() async -> Result<AsyncSocket, Error> {
+      await Result {
+        try await socket.accept()
+      }.mapError(Error.failedToAcceptConnection)
+    }
+
+    static func handshake(_ connection: inout AsyncSocket) async -> Result<(), Error> {
+      await Result {
+        try await Packet.ping.write(to: &connection)
+        return try await Packet.read(from: &connection)
+      }.mapError(Error.failedToSendPing).andThen { response in
+        guard case Packet.pong = response else {
+          return .failure(.expectedPong(response))
+        }
+        return .success()
+      }
     }
   }
-
-  func accept() async -> Result<AsyncSocket, Error> {
-    await Result {
-      try await socket.accept()
-    }.mapError(Error.failedToAcceptConnection)
-  }
-
-  static func handshake(_ connection: inout AsyncSocket) async -> Result<(), Error> {
-    await Result {
-      try await Packet.ping.write(to: &connection)
-      return try await Packet.read(from: &connection)
-    }.mapError(Error.failedToSendPing).andThen { response in
-      guard case Packet.pong = response else {
-        return .failure(.expectedPong(response))
-      }
-      return .success()
-    }
-  }
-}
+#endif

--- a/Sources/SwiftBundler/Bundler/HotReloadingServer.swift
+++ b/Sources/SwiftBundler/Bundler/HotReloadingServer.swift
@@ -1,0 +1,169 @@
+import FileSystemWatcher
+import FlyingSocks
+import Foundation
+import HotReloadingProtocol
+
+#if canImport(Darwin)
+  import Darwin
+#elseif canImport(Glibc)
+  import Glibc
+#elseif canImport(WinSDK)
+  import WinSDK.WinSock2
+#endif
+
+struct HotReloadingServer {
+  let port: UInt16
+  let socket: AsyncSocket
+
+  enum Error: LocalizedError {
+    case failedToSendPing(Swift.Error)
+    case expectedPong(Packet)
+    case addrInUse
+    case failedToCreateSocket(Swift.Error)
+    case failedToAcceptConnection(Swift.Error)
+    case failedToWatchPackage(Swift.Error)
+
+    var errorDescription: String? {
+      switch self {
+        case .failedToSendPing(let error):
+          return "Failed to send ping: \(error.localizedDescription)"
+        case .expectedPong(let response):
+          return "Expected pong, got '\(response)'"
+        case .addrInUse:
+          return "Failed to create socket: Address in use"
+        case .failedToCreateSocket(let error):
+          return "Failed to create socket: \(error.localizedDescription)"
+        case .failedToAcceptConnection(let error):
+          return "Failed to accept connection: \(error.localizedDescription)"
+        case .failedToWatchPackage(let error):
+          return "Failed to watch package: \(error.localizedDescription)"
+      }
+    }
+  }
+
+  static func create(portHint: UInt16 = 7331) async -> Result<Self, Error> {
+    var port = portHint
+    let socket: AsyncSocket
+
+    // Attempt to create socket and if the address is already in use, retry with
+    // higher and higher ports until socket creation fails for another reason or
+    // a free address is found.
+    outer: while true {
+      switch await Self.createSocket(port: port) {
+        case .success(let value):
+          socket = value
+          break outer
+        case .failure(.addrInUse):
+          port += 1
+        case .failure(let error):
+          return .failure(error)
+      }
+    }
+
+    return .success(Self(port: port, socket: socket))
+  }
+
+  static func createSocket(port: UInt16) async -> Result<AsyncSocket, Error> {
+    do {
+      let address: SocketAddress = try .inet(ip4: "127.0.0.1", port: port)
+      let socket = try Socket(domain: Int32(type(of: address).family))
+      try socket.bind(to: address)
+      try socket.listen()
+
+      let pool = SocketPool.make()
+      try await pool.prepare()
+      Task {
+        try await pool.run()
+      }
+
+      let asyncSocket = try AsyncSocket(
+        socket: socket,
+        pool: pool
+      )
+      return .success(asyncSocket)
+    } catch let error as SocketError {
+      let addrInUse: Int32
+      #if canImport(Darwin) || canImport(Glibc)
+        addrInUse = EADDRINUSE
+      #elseif canImport(WinSDK)
+        addrInUse = WSAEADDRINUSE
+      #endif
+
+      guard
+        case let .failed(_, errno, _) = error,
+        errno == addrInUse
+      else {
+        return .failure(.failedToCreateSocket(error))
+      }
+
+      return .failure(.addrInUse)
+    } catch {
+      return .failure(.failedToCreateSocket(error))
+    }
+  }
+
+  func start(
+    product: String,
+    buildContext: SwiftPackageManager.BuildContext
+  ) async -> Result<(), Error> {
+    var connection: AsyncSocket
+    switch await accept() {
+      case .success(let value):
+        connection = value
+      case .failure(let error):
+        return .failure(error)
+    }
+
+    log.debug("Received connection from runtime")
+
+    return await Self.handshake(&connection).andThen { _ in
+      log.debug("Handshake succeeded")
+      let sourcesDirectory = buildContext.genericContext.projectDirectory / "Sources"
+      return await Result {
+        try await FileSystemWatcher.watch(
+          paths: [sourcesDirectory.path],
+          with: {
+            log.info("Building 'lib\(product).dylib'")
+            let connection = connection
+            Task {
+              do {
+                var connection = connection
+                let dylibFile = try await SwiftPackageManager.buildExecutableAsDylib(
+                  product: product,
+                  buildContext: buildContext
+                ).unwrap()
+                log.info("Successfully built dylib")
+
+                try await Packet.reloadDylib(path: dylibFile).write(to: &connection)
+              } catch {
+                log.error("Hot reloading failed: \(error.localizedDescription)")
+              }
+            }
+          },
+          errorHandler: { error in
+            log.error("Hot reloading failed: \(error.localizedDescription)")
+          }
+        )
+      }
+      .mapError(Error.failedToWatchPackage)
+    }
+  }
+
+  func accept() async -> Result<AsyncSocket, Error> {
+    await Result {
+      try await socket.accept()
+    }.mapError(Error.failedToAcceptConnection)
+  }
+
+  static func handshake(_ connection: inout AsyncSocket) async -> Result<(), Error> {
+    await Result {
+      try await Packet.ping.write(to: &connection)
+      return try await Packet.read(from: &connection)
+    }.mapError(Error.failedToSendPing).andThen { response in
+      guard case Packet.pong = response else {
+        return .failure(.expectedPong(response))
+      }
+      return .success()
+    }
+  }
+}

--- a/Sources/SwiftBundler/Bundler/Templater/Templater.swift
+++ b/Sources/SwiftBundler/Bundler/Templater/Templater.swift
@@ -184,13 +184,13 @@ enum Templater {
     }
 
     // Apply the template
-    return await applyTemplate(
+    return applyTemplate(
       templateDirectory,
       to: outputDirectory,
       packageName: packageName,
       identifier: configuration.identifier,
       indentationStyle: indentationStyle
-    ).mapError { error in
+    ).mapError { error -> TemplaterError in
       // Cleanup output directory
       attemptCleanup(outputDirectory)
       return error
@@ -200,7 +200,7 @@ enum Templater {
         packageName: packageName,
         configuration: configuration
       )
-    }.map { _ in
+    }.map { _ -> Template in
       Template(name: template, manifest: manifest)
     }
   }

--- a/Sources/SwiftBundler/Configuration/PackageConfiguration.swift
+++ b/Sources/SwiftBundler/Configuration/PackageConfiguration.swift
@@ -198,7 +198,7 @@ struct PackageConfiguration: Codable {
         TOMLDecoder().decode(PackageConfigurationV2.self, from: contents)
           .mapError(PackageConfigurationError.failedToDeserializeV2Configuration)
       }
-      .map { oldConfiguration in
+      .mapAsync { oldConfiguration in
         // Migrate the configuration
         await oldConfiguration.migrate()
       }

--- a/Sources/SwiftBundler/Extensions/Process.swift
+++ b/Sources/SwiftBundler/Extensions/Process.swift
@@ -106,7 +106,7 @@ extension Process {
     }
 
     return await runAndWait()
-      .map { _ in
+      .mapAsync { _ in
         await finalize()
       }
       .mapErrorAsync { error in

--- a/Sources/SwiftBundler/Extensions/Result.swift
+++ b/Sources/SwiftBundler/Extensions/Result.swift
@@ -337,7 +337,7 @@ func set<T, U>(_ property: WritableKeyPath<T, U>, _ value: U) -> (T) -> T {
 }
 
 extension Result {
-  func map<NewSuccess>(
+  func mapAsync<NewSuccess>(
     _ transform: (Success) async -> NewSuccess
   ) async -> Result<NewSuccess, Failure> {
     switch self {

--- a/Tests/SwiftBundlerTests/SwiftBundlerTests.swift
+++ b/Tests/SwiftBundlerTests/SwiftBundlerTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 
-@testable import swift_bundler
+@testable import SwiftBundler
 
 final class SwiftBundlerTests: XCTestCase {
   func testCommandLineParsing() throws {


### PR DESCRIPTION
I've run into quite a few cross-platform compatability issues with [PureSwift/Socket](https://github.com/PureSwift/Socket) in the past. Additionally, `PureSwift/Socket` generally hasn't been very actively maintained (to the point where I have my own fork). gregc just encountered another `PureSwift/Socket` related issue, which served as the catalyst for this set of changes. These changes switch Swift Bundler over to `FlyingSocks` (in [swhitty/FlyingFox](https://github.com/swhitty/FlyingFox)) for all its socket needs.

These changes also move the hot reloading server run loop out of `RunCommand` into its own file.