### PR TITLE
General Linux / RPM improvements

### DIFF
--- a/Sources/SwiftBundler/Bundler/GenericLinuxBundler.swift
+++ b/Sources/SwiftBundler/Bundler/GenericLinuxBundler.swift
@@ -131,7 +131,7 @@ enum GenericLinuxBundler: Bundler {
     init(at root: URL, forApp appName: String, withIdentifier appIdentifier: String) {
       self.root = root
       bin = root.appendingPathComponent("usr/bin")
-      mainExecutable = bin.appendingPathComponent(appName)
+      mainExecutable = bin.appendingPathComponent(appName.replacingOccurrences(of: " ", with: "-").lowercased())
       lib = root.appendingPathComponent("usr/lib")
       resources = bin
       // TODO: Resize the icon to 512x512, 1024x1024 isn't supported by xdg stuff

--- a/Sources/SwiftBundler/Bundler/GenericLinuxBundler.swift
+++ b/Sources/SwiftBundler/Bundler/GenericLinuxBundler.swift
@@ -493,7 +493,7 @@ enum GenericLinuxBundler: Bundler {
       ("Type", "Application"),
       ("Version", "1.0"),  // The version of the target desktop spec, not the app
       ("Name", appName),
-      ("Comment", ""),
+      ("Comment", appConfiguration.appDescriptionOrDefault),
       ("Exec", "\(escapedExecPath) %U"),
       ("Icon", iconName),
       ("Terminal", "false"),

--- a/Sources/SwiftBundler/Bundler/RPMBundler.swift
+++ b/Sources/SwiftBundler/Bundler/RPMBundler.swift
@@ -28,7 +28,7 @@ enum RPMBundler: Bundler {
     let outputStructure = intendedOutput(in: context, additionalContext)
     let bundleName = outputStructure.bundle.lastPathComponent
 
-    let escapedAppName = context.appName.replacingOccurrences(of: " ", with: "-")
+    let escapedAppName = context.appName.replacingOccurrences(of: " ", with: "-").lowercased()
     let appVersion = context.appConfiguration.version
     let rpmBuildDirectory = RPMBuildDirectory(
       at: context.outputDirectory / "rpmbuild",

--- a/Sources/SwiftBundler/Bundler/RPMBundler.swift
+++ b/Sources/SwiftBundler/Bundler/RPMBundler.swift
@@ -40,7 +40,7 @@ enum RPMBundler: Bundler {
     // cause it's all pre-compiled.
     let sourceDirectory = context.outputDirectory / "\(escapedAppName)-\(appVersion)"
 
-    let installationRoot = URL(fileURLWithPath: "/opt/\(context.appName)")
+    let installationRoot = URL(fileURLWithPath: "/opt/\(escapedAppName)")
     return await GenericLinuxBundler.bundle(
       context,
       GenericLinuxBundler.Context(

--- a/Sources/SwiftBundler/Bundler/RPMBundler.swift
+++ b/Sources/SwiftBundler/Bundler/RPMBundler.swift
@@ -81,6 +81,8 @@ enum RPMBundler: Bundler {
         escapedAppName: escapedAppName,
         appIdentifier: context.appConfiguration.identifier,
         appVersion: appVersion,
+        appDescription: context.appConfiguration.appDescriptionOrDefault,
+        appLicense: context.appConfiguration.licenseOrDefault,
         bundleStructure: structure,
         sourceArchiveName: rpmBuildDirectory.appSourceArchive.lastPathComponent,
         installationRoot: installationRoot,
@@ -137,6 +139,8 @@ enum RPMBundler: Bundler {
     escapedAppName: String,
     appIdentifier: String,
     appVersion: String,
+    appDescription: String,
+    appLicense: String,
     bundleStructure: GenericLinuxBundler.BundleStructure,
     sourceArchiveName: String,
     installationRoot: URL,
@@ -188,9 +192,9 @@ enum RPMBundler: Bundler {
       Name:           \(escapedAppName)
       Version:        \(appVersion)
       Release:        1%{?dist}
-      Summary:        An app bundled by Swift Bundler
+      Summary:        \(appDescription)
 
-      License:        MIT
+      License:        \(appLicense)
       Source0:        \(sourceArchiveName)
 
       \(requirements.map { "Requires:       \($0)" }.joined(separator: "\n"))
@@ -203,7 +207,7 @@ enum RPMBundler: Bundler {
       %global __os_install_post /usr/lib/rpm/brp-compress %{nil}
 
       %description
-      An app bundled by Swift Bundler
+      \(appDescription)
 
       %prep
       %setup

--- a/Sources/SwiftBundler/Configuration/AppConfiguration.swift
+++ b/Sources/SwiftBundler/Configuration/AppConfiguration.swift
@@ -9,6 +9,10 @@ struct AppConfiguration: Codable {
   var product: String
   /// The app's current version.
   var version: String
+  /// A short summary describing the purpose of the app.
+  var appDescription: String?
+  /// The license type of the app.
+  var license: String?
   // swiftlint:disable:next line_length
   /// The app's category. See [Apple's documentation](https://developer.apple.com/documentation/bundleresources/information_property_list/lsapplicationcategorytype) for more details.
   var category: String?
@@ -46,6 +50,8 @@ struct AppConfiguration: Codable {
     case identifier
     case product
     case version
+    case appDescription = "description"
+    case license
     case category
     case icon
     case urlSchemes = "url_schemes"
@@ -61,6 +67,8 @@ struct AppConfiguration: Codable {
     var identifier: String
     var product: String
     var version: String
+    var appDescription: String?
+    var license: String?
     var category: String?
     var icon: String?
     var urlSchemes: [String]
@@ -131,6 +139,8 @@ struct AppConfiguration: Codable {
     var identifier: String?
     var product: String?
     var version: String?
+    var appDescription: String?
+    var license: String?
     var category: String?
     var icon: String?
     var urlSchemes: [String]?
@@ -145,6 +155,8 @@ struct AppConfiguration: Codable {
       case identifier
       case product
       case version
+      case appDescription = "description"
+      case license
       case category
       case icon
       case urlSchemes = "url_schemes"
@@ -159,6 +171,8 @@ struct AppConfiguration: Codable {
       Self.merge(&base.identifier, identifier)
       Self.merge(&base.product, product)
       Self.merge(&base.version, version)
+      Self.merge(&base.appDescription, appDescription)
+      Self.merge(&base.license, license)
       Self.merge(&base.category, category)
       Self.merge(&base.icon, icon)
       Self.merge(&base.urlSchemes, urlSchemes)
@@ -272,5 +286,15 @@ struct AppConfiguration: Codable {
       } ?? filteredDictionary
 
     return configuration
+  }
+}
+
+extension AppConfiguration.Flat {
+  var appDescriptionOrDefault: String {
+    appDescription ?? "None"
+  }
+
+  var licenseOrDefault: String {
+    license ?? "Unknown"
   }
 }

--- a/Sources/SwiftBundler/Configuration/ConfigurationFlattener.swift
+++ b/Sources/SwiftBundler/Configuration/ConfigurationFlattener.swift
@@ -121,6 +121,8 @@ enum ConfigurationFlattener {
         identifier: configuration.identifier,
         product: configuration.product,
         version: configuration.version,
+        appDescription: configuration.appDescription,
+        license: configuration.license,
         category: configuration.category,
         icon: configuration.icon,
         urlSchemes: configuration.urlSchemes ?? [],


### PR DESCRIPTION
A few tweaks to get things to be more "Linux-like":

1. The main executable should be dash-escaped, and all lower case. For example, if your app is "Google Chrome", the main executable should actually be "google-chrome"
2. The RPM package name should mirror the main executable's naming scheme. "Google Chrome" -> "google-chrome"
3. The RPM was populating some placeholder info for the description/summary and license. I added optional properties, `description` and `license` to the TOML spec.