### PR TITLE
Subsequent builds using `--strip` fail

### DIFF
--- a/Sources/SwiftBundler/Commands/BundleCommand.swift
+++ b/Sources/SwiftBundler/Commands/BundleCommand.swift
@@ -699,6 +699,7 @@ struct BundleCommand: ErrorHandledCommand {
         }
 
         if arguments.strip {
+          try? FileManager.default.removeItem(at: executableArtifact)
           try FileManager.default.copyItem(at: originalExecutableArtifact, to: executableArtifact)
           try await Stripper.strip(executableArtifact).unwrap()
         }


### PR DESCRIPTION
Adds a failable `removeItem` before the `copyItem` of the main executable.