### PR TITLE
Ensure provisioningprofile matches signing cert (not just identity name)

### DIFF
--- a/Sources/SwiftBundler/Bundler/CodeSigner/CodeSignerError.swift
+++ b/Sources/SwiftBundler/Bundler/CodeSigner/CodeSignerError.swift
@@ -13,7 +13,9 @@ enum CodeSignerError: LocalizedError {
   case failedToParseSigningCertificate(pem: String, Error)
   case signingCertificateMissingTeamIdentifier(CodeSigner.Identity)
   case identityShortNameNotMatched(String)
-  case failedToLocateLatestCertificate(CodeSigner.Identity)
+  case failedToLocateCertificate(CodeSigner.Identity)
+  case invalidId(String)
+  case certificateExpired(CodeSigner.Identity, notValidAfter: Date)
 
   var errorDescription: String? {
     switch self {
@@ -50,10 +52,17 @@ enum CodeSignerError: LocalizedError {
           Identity short name '\(shortName)' didn't match any known identities. \
           Run 'swift bundler list-identities' to list available identities.
           """
-      case .failedToLocateLatestCertificate(let identity):
+      case .failedToLocateCertificate(let identity):
         return """
-          Failed to locate latest signing certificate for identity \
-          '\(identity.name)'
+          Failed to locate signing certificate for identity \
+          '\(identity.name)' (id: \(identity.id))
+          """
+      case .invalidId(let id):
+        return "Invalid code signing id '\(id)', expected hexadecimal string."
+      case .certificateExpired(let identity, let notValidAfter):
+        return """
+          The certificate corresponding to code signing identity '\(identity.name)'
+          with SHA-1 hash '\(identity.id)' expired at \(notValidAfter).
           """
     }
   }

--- a/Sources/SwiftBundler/Bundler/ProvisioningProfileManager/ProvisioningProfile.swift
+++ b/Sources/SwiftBundler/Bundler/ProvisioningProfileManager/ProvisioningProfile.swift
@@ -12,7 +12,7 @@ struct ProvisioningProfile {
   let platforms: [String]
   let appId: String
   let entitlements: Entitlements
-  let certificates: [Certificate]
+  let certificates: [(certificate: Certificate, derEncoded: [UInt8])]
 
   enum CodingKeys: String, CodingKey {
     case teamIdentifierArray = "TeamIdentifier"
@@ -65,9 +65,14 @@ extension ProvisioningProfile: Decodable {
       platforms: try container.decode([String].self, forKey: .platforms),
       appId: try container.decode(String.self, forKey: .appId),
       entitlements: try container.decode(Entitlements.self, forKey: .entitlements),
-      certificates: try container.decode([Data].self, forKey: .certificates).map { certificateDER in
-        try Certificate(derEncoded: [UInt8](certificateDER))
-      }
+      certificates: try container.decode([Data].self, forKey: .certificates)
+        .map { certificateDER in
+          let bytes = [UInt8](certificateDER)
+          return (
+            try Certificate(derEncoded: bytes),
+            bytes
+          )
+        }
     )
   }
 }

--- a/Sources/SwiftBundler/Extensions/Sequence.swift
+++ b/Sources/SwiftBundler/Extensions/Sequence.swift
@@ -17,3 +17,21 @@ extension Sequence where Element == String {
     return output
   }
 }
+
+extension Array where Element == UInt8 {
+  init?(fromHex hex: String) {
+    guard hex.count % 2 == 0 else {
+      return nil
+    }
+
+    self = []
+    for index in 0..<(hex.count / 2) {
+      let start = hex.index(hex.startIndex, offsetBy: index * 2)
+      let end = hex.index(start, offsetBy: 2)
+      guard let byte = UInt8(hex[start..<end], radix: 16) else {
+        return nil
+      }
+      self.append(byte)
+    }
+  }
+}

--- a/Tests/SwiftBundlerTests/SwiftBundlerTests.swift
+++ b/Tests/SwiftBundlerTests/SwiftBundlerTests.swift
@@ -48,6 +48,13 @@ import Foundation
   await SwiftBundler.main(["--verbose", "bundle", "HelloWorld", "-d", directory.path, "-o", directory.path])
 }
 
+@Test func testHexParsing() throws {
+  #expect(Array(fromHex: "AB5D87") == [0xab, 0x5d, 0x87])
+  #expect(Array(fromHex: "ab5d87") == [0xab, 0x5d, 0x87])
+  #expect(Array(fromHex: "ef917") == nil)
+  #expect(Array(fromHex: "ef917g") == nil)
+}
+
 #if os(macOS)
   /// This test app depends on both a plain dynamic library and a framework.
   @Test func testDarwinDynamicDependencyCopying() async throws {


### PR DESCRIPTION
We used to only require that provisioning profiles matched at least one certificate corresponding to the selected code signing identity's name, but this was incorrect because what actually matters is the certificate we end up using to sign the executable, which is uniquely determined by the code signing identity's id (the certificate's SHA-1 hash), not its human-facing name. I've updating `CodeSigner` and `ProvisioningProfileManager` to correctly handle this correlation between code signing identities and certificates now.