### PR TITLE
Fix library install name updating logic (fixes issue #85)

### DIFF
--- a/Sources/SwiftBundler/Bundler/DynamicLibraryBundler.swift
+++ b/Sources/SwiftBundler/Bundler/DynamicLibraryBundler.swift
@@ -262,8 +262,8 @@ enum DynamicLibraryBundler {
 
     // Update the install name of the dylib
     let outputDylib = isFramework
-      ? dependency.appendingPathComponent(dylibLocation.path(relativeTo: framework))
-      : dependency
+      ? outputDependency.appendingPathComponent(dylibLocation.path(relativeTo: framework))
+      : outputDependency
     let newRelativePath = outputDylib.path(
       relativeTo: binary.deletingLastPathComponent()
     )

--- a/Tests/SwiftBundlerTests/SwiftBundlerTests.swift
+++ b/Tests/SwiftBundlerTests/SwiftBundlerTests.swift
@@ -62,8 +62,16 @@ import Foundation
     let library = outputPath / "Contents/Libraries/libLibrary.dylib"
     #expect(library.exists(), "didn't copy dynamic library")
 
+    // Move the app and remove the debug directory to ensure that the app
+    // is relocatable and independent of any compile-time artifacts. See
+    // issue #85.
+    let appCopy = fixture / "\(app).app"
+    try? FileManager.default.removeItem(at: appCopy)
+    try FileManager.default.copyItem(at: outputPath, to: appCopy)
+    try FileManager.default.removeItem(at: fixture / ".build")
+
     // Ensure that the copied dynamic dependencies are usable by the app.
-    let executable = outputPath / "Contents/MacOS/\(app)"
+    let executable = appCopy / "Contents/MacOS/\(app)"
     let process = Process.create(executable.path)
     let output = try await process.getOutput().unwrap()
     #expect(


### PR DESCRIPTION
See #85 for details. I've fixed the logic error and updated the dynamic library bundling test to catch the original logic error.