### PR TITLE
Fix update-docs workflow

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -2,7 +2,8 @@ name: Update Docs
 
 on:
   push:
-    branches: [ main ]
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   update-docs:
@@ -13,7 +14,7 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Compile Docs
+      - name: Compile docs
         run: |
           set -eux
 
@@ -31,6 +32,7 @@ jobs:
           export SWIFTPM_ENABLE_COMMAND_PLUGINS=1 
           export DOCC_HTML_DIR=../swift-docc-render-artifact/dist
           swift package \
+            --disable-experimental-prebuilts \
             --allow-writing-to-directory gh-pages/docs \
             generate-documentation \
             --target swift-bundler \
@@ -56,6 +58,11 @@ jobs:
           # On macOS, replace `-i` with `-i '' -e`
           LC_ALL=C find docs -type f -exec sed -i 's/swift_bundler/swift-bundler/g' {} \;
           
+      - name: Update docs (if on main branch)
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: |
+          set -eux
+
           # Commit changes back to gh-pages branch if there any
           git add docs
           if [ -n "$(git status --porcelain)" ]; then

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f2b66a9afd11df9615459ec0ca70da2121c9154558b337bc6bc4bb796db6c358",
+  "originHash" : "b2d257e73cc8c1e370ef50e54b707d4d27ed45d94f2f4a02777fe7e9a4a3da1e",
   "pins" : [
     {
       "identity" : "aexml",
@@ -204,7 +204,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stackotter/swift-macro-toolkit",
       "state" : {
-        "revision" : "2bfe6affb6b429babd9619f9eb0f629e6e91eefc"
+        "revision" : "dea76b658a808d8611540f016e4cbdba126a779b",
+        "version" : "0.7.1"
       }
     },
     {


### PR DESCRIPTION
The update-docs workflow broke due to the Swift Syntax prebuilts issue that I encountered with the Linux workflow yesterday. This PR fixes that, and also updates the workflow to run on every push and pull request (just without actually committing the docs changes unless on the main branch) so that we can catch these sorts of issues before pushing them to the main branch.