### PR TITLE
Fix update-docs' Update step (broke in #100)

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -62,6 +62,7 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' }}
         run: |
           set -eux
+          cd gh-pages
 
           # Commit changes back to gh-pages branch if there any
           git add docs


### PR DESCRIPTION
#100 broke the 'Update docs' step when it split the update step into separate compile and update steps. The underlying cause was a missing cd (which needs to be repeated in the update step due to the original cd being in a separate step now).