### PR TITLE
Add iPad support

### DIFF
--- a/Sources/SwiftBundler/Bundler/PlistCreator.swift
+++ b/Sources/SwiftBundler/Bundler/PlistCreator.swift
@@ -108,6 +108,7 @@ enum PlistCreator {
         entries["MinimumOSVersion"] = platformVersion
         entries["CFBundleSupportedPlatforms"] = ["iPhoneOS"]
         entries["UILaunchScreen"] = [String: Any]()
+        entries["UIDeviceFamily"] = [1, 2]
       case .tvOS, .tvOSSimulator:
         entries["MinimumOSVersion"] = platformVersion
         entries["CFBundleSupportedPlatforms"] = ["AppleTVOS"]


### PR DESCRIPTION
Allows iOS apps to run natively on iPad, rather than in a tiny window simulating an iPhone.