### PR TITLE
[FIX] undefined: main linker issue on windows 11 with swift 6.2

### DIFF
--- a/Sources/SwiftBundler/Bundler/SwiftPackageManager/SwiftPackageManager.swift
+++ b/Sources/SwiftBundler/Bundler/SwiftPackageManager/SwiftPackageManager.swift
@@ -214,7 +214,8 @@ enum SwiftPackageManager {
         if buildContext.isGUIExecutable {
           let frontendArguments = ["-entry-point-function-name", "wWinMain"]
           let swiftcArguments = frontendArguments.flatMap { ["-Xfrontend", $0] }
-          guiArguments = swiftcArguments.flatMap { ["-Xswiftc", $0] }
+          guiArguments = swiftcArguments.flatMap { ["-Xswiftc", $0] } +
+            ["-Xlinker", "/SUBSYSTEM:WINDOWS"]
         } else {
           guiArguments = []
         }


### PR DESCRIPTION
added -Xlinker /SUBSYSTEM:WINDOWS argument for gui apps on windows.

I discarded changes from the format script, because it would’ve added a ton of unrelated changes.