### PR TITLE
Fix Assets.car creation

### DIFF
--- a/Sources/SwiftBundler/Bundler/ResourceBundler.swift
+++ b/Sources/SwiftBundler/Bundler/ResourceBundler.swift
@@ -148,7 +148,6 @@ enum ResourceBundler {
     }
 
     let assetCatalog = destinationBundleResources.appendingPathComponent("Assets.xcassets")
-    let assetCatalogExists = assetCatalog.exists(withType: .directory)
 
     if !isMainBundle {
       // All resource bundles other than the main one get put in separate
@@ -164,7 +163,7 @@ enum ResourceBundler {
 
     try copyResources(from: bundle, to: destinationBundleResources)
 
-    if assetCatalogExists {
+    if assetCatalog.exists(withType: .directory) {
       // Compile asset catalog if present
       try await compileAssetCatalog(
         assetCatalog,


### PR DESCRIPTION
This pull request makes a minor improvement to the resource bundling logic by simplifying how the existence of the asset catalog directory is checked before compiling it.

- Resource bundling logic:
  * In `ResourceBundler`, replaced the separate `assetCatalogExists` variable with an inline check for the asset catalog directory's existence in the `if` statement, making the code more concise. [[1]](diffhunk://#diff-0667bcb7efdc61cfeed16281d58ea116a917835d6d72089ed0ede58383f0de33L151) [[2]](diffhunk://#diff-0667bcb7efdc61cfeed16281d58ea116a917835d6d72089ed0ede58383f0de33L167-R166)
  
Closes: #115 