### PR TITLE
Fix initial hot reloading incremental build (fixes #130)

### DIFF
--- a/Sources/SwiftBundler/Commands/RunCommand.swift
+++ b/Sources/SwiftBundler/Commands/RunCommand.swift
@@ -139,18 +139,14 @@ struct RunCommand: ErrorHandledCommand {
     let additionalEnvironmentVariables: [String: String]
     #if SUPPORT_HOT_RELOADING
       if hot {
-        let buildContext = SwiftPackageManager.BuildContext(
-          genericContext: GenericBuildContext(
-            projectDirectory: packageDirectory,
-            scratchDirectory: scratchDirectory,
-            configuration: arguments.buildConfiguration,
-            architectures: architectures,
-            platform: device.platform,
-            platformVersion: platformVersion,
-            additionalArguments: arguments.additionalSwiftPMArguments
-          ),
-          hotReloadingEnabled: true,
-          isGUIExecutable: true
+        let buildContext = GenericBuildContext(
+          projectDirectory: packageDirectory,
+          scratchDirectory: scratchDirectory,
+          configuration: arguments.buildConfiguration,
+          architectures: architectures,
+          platform: device.platform,
+          platformVersion: platformVersion,
+          additionalArguments: arguments.additionalSwiftPMArguments
         )
 
         // Start server and file system watcher (integrated into server)
@@ -162,7 +158,8 @@ struct RunCommand: ErrorHandledCommand {
           do {
             try await server.start(
               product: appConfiguration.product,
-              buildContext: buildContext
+              buildContext: buildContext,
+              appConfiguration: appConfiguration
             )
           } catch {
             log.error(


### PR DESCRIPTION
This PR fixes #130. It's not a very nice solution, but it's not worse than before. I looked into extracting the core building logic out of BundleCommand and I don't think there's a way to do it without a rather involved refactor which I don't have time for right now. BundleCommand is truely a mess. I think a few days of Swift Bundler tech debt clean up are due in the next few weeks.