### PR TITLE
Fix HotReloadingClient sendability warning

### DIFF
--- a/Sources/SwiftBundlerRuntime/HotReloadingClient.swift
+++ b/Sources/SwiftBundlerRuntime/HotReloadingClient.swift
@@ -16,7 +16,7 @@ public enum HotReloadingClientError: LocalizedError {
   }
 }
 
-public struct HotReloadingClient {
+public struct HotReloadingClient: Sendable {
   var server: AsyncSocket
 
   /// Connects to the server specified by the `SWIFT_BUNDLER_SERVER` environment variable.


### PR DESCRIPTION
This PR fixes an annoying HotReloadingClient sendability warning that SwiftCrossUI users would get when using hot reloading. The fix was just to make HotReloadingClient `Sendable`.