### PR TITLE
Add sending annotation to help fix SCUI hot reloading macro concurrency error

### DIFF
--- a/Sources/SwiftBundlerRuntime/HotReloadingClient.swift
+++ b/Sources/SwiftBundlerRuntime/HotReloadingClient.swift
@@ -36,7 +36,7 @@ public struct HotReloadingClient: Sendable {
   }
 
   #if canImport(Darwin)
-    public mutating func handlePackets(handleDylib: (Dylib) -> Void) async throws {
+    public mutating func handlePackets(handleDylib: (sending Dylib) -> Void) async throws {
       while true {
         let packet = try await Packet.read(from: &server)
 


### PR DESCRIPTION
Building a SwiftCrossUI hot reloading app in the Swift 6 language mode causes compile time concurrency safety errors. This `sending` annotation helps fix the concurrency issues.