### PR TITLE
Add ghall89/AutoDock to readme projects section

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,4 @@ If you have made an app with Swift Bundler, I'd love to hear about it! Just open
 - [Delta Client](https://github.com/stackotter/delta-client): A 'Minecraft: Java Edition' compatible Minecraft client written from scratch in Swift (macOS only)
 - [ModularMTL](https://github.com/JezewskiG/ModularMTL): A modular multiplication visualisation made with Swift Bundler, SwiftUI and Metal (macOS only)
 - [Friend](https://github.com/JoshuaBrest/Friend): A technical demo that showcases how system-based assistants can be integrated with LLMs to provide greater flexibility and functionality (macOS only)
+- [AutoDock](https://github.com/ghall89/AutoDock): A utility for automatically hiding and showing the macOS Dock based on connected display size. (macOS only)


### PR DESCRIPTION
Adds AutoDock to the README.md projects section with a link to the GitHub repo.