### PR TITLE
CI: Give update-docs workflow write perms (post-transfer fixup)

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   update-docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Swift version
         run: swift --version


### PR DESCRIPTION
Have to do this now that the repo is under an org instead of a personal account.