### PR TITLE
Fix certificate locating logic (fixes #124)

### DIFF
--- a/Sources/SwiftBundler/Bundler/CodeSigner/CodeSigner.swift
+++ b/Sources/SwiftBundler/Bundler/CodeSigner/CodeSigner.swift
@@ -255,7 +255,7 @@ enum CodeSigner {
       output = try await Process.create(
         securityToolPath,
         arguments: [
-          "find-certificate", "-c", identity.id, "-p", "-a",
+          "find-certificate", "-c", identity.name, "-p", "-a",
         ]
       ).getOutput()
     } catch {
@@ -283,7 +283,7 @@ enum CodeSigner {
     }
 
     guard let certificatePEM = certificates.first else {
-      throw Error(.failedToLocateCertificate(identity))
+      throw Error(.failedToLocateSigningCertificate(identity))
     }
 
     if certificates.count > 1 {

--- a/Sources/SwiftBundler/Bundler/CodeSigner/CodeSignerError.swift
+++ b/Sources/SwiftBundler/Bundler/CodeSigner/CodeSignerError.swift
@@ -17,7 +17,6 @@ extension CodeSigner {
     case failedToParseSigningCertificate(pem: String)
     case signingCertificateMissingTeamIdentifier(CodeSigner.Identity)
     case identityShortNameNotMatched(String)
-    case failedToLocateCertificate(CodeSigner.Identity)
     case invalidId(String)
     case certificateExpired(CodeSigner.Identity, notValidAfter: Date)
 
@@ -50,11 +49,6 @@ extension CodeSigner {
           return """
             Identity short name '\(shortName)' didn't match any known identities. \
             Run 'swift bundler list-identities' to list available identities.
-            """
-        case .failedToLocateCertificate(let identity):
-          return """
-            Failed to locate signing certificate for identity \
-            '\(identity.name)' (id: \(identity.id))
             """
         case .invalidId(let id):
           return "Invalid code signing id '\(id)', expected hexadecimal string."


### PR DESCRIPTION
This fixes the bug reported in #124. The fix is exactly what @surinrasu said that it was. It seems that I never reached this code path in my own usage due to a long-lived wild card provisioning profile on my machine.