### PR TITLE
Fix xcodebuild destination architecture handling (fixes #126)

### DIFF
--- a/Sources/SwiftBundler/Bundler/HostPlatform.swift
+++ b/Sources/SwiftBundler/Bundler/HostPlatform.swift
@@ -1,5 +1,5 @@
 /// A supported Swift Bundler host platform.
-enum HostPlatform {
+enum HostPlatform: Sendable, Hashable {
   case macOS
   case linux
   case windows

--- a/Sources/SwiftBundler/Bundler/NonMacAppleOS.swift
+++ b/Sources/SwiftBundler/Bundler/NonMacAppleOS.swift
@@ -1,5 +1,5 @@
 /// A non-macOS Apple operating system.
-enum NonMacAppleOS: CaseIterable {
+enum NonMacAppleOS: Sendable, CaseIterable {
   case iOS
   case tvOS
   case visionOS

--- a/Sources/SwiftBundler/Bundler/NonMacApplePlatform.swift
+++ b/Sources/SwiftBundler/Bundler/NonMacApplePlatform.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// A non-macOS Apple platform. Used to model Apple platforms that can be
 /// connected to computers to become run destinations.
-enum NonMacApplePlatform: Equatable {
+enum NonMacApplePlatform: Sendable, Equatable {
   case physical(NonMacAppleOS)
   case simulator(NonMacAppleOS)
 

--- a/Sources/SwiftBundler/Bundler/ProjectBuilder.swift
+++ b/Sources/SwiftBundler/Bundler/ProjectBuilder.swift
@@ -423,7 +423,7 @@ enum ProjectBuilder {
         projectDirectory: scratchDirectory.builder,
         scratchDirectory: scratchDirectory.builder / ".build",
         configuration: .debug,
-        architectures: [.current],
+        architectures: [.host],
         platform: HostPlatform.hostPlatform.platform,
         additionalArguments: []
       ),

--- a/Sources/SwiftBundler/Bundler/Runner/ConnectedDevice.swift
+++ b/Sources/SwiftBundler/Bundler/Runner/ConnectedDevice.swift
@@ -1,9 +1,10 @@
 /// A connected device or simulator.
-struct ConnectedDevice: Equatable {
+struct ConnectedDevice: Sendable, Equatable {
   let platform: NonMacApplePlatform
   let name: String
   let id: String
   let status: Status
+  let architecture: BuildArchitecture
 
   enum Status: Equatable, CustomStringConvertible {
     case available

--- a/Sources/SwiftBundler/Bundler/Runner/Device.swift
+++ b/Sources/SwiftBundler/Bundler/Runner/Device.swift
@@ -2,25 +2,27 @@ import ArgumentParser
 import Foundation
 
 /// A device that can be used to run apps.
-enum Device: Equatable, CustomStringConvertible {
-  case host(HostPlatform)
+enum Device: Sendable, Equatable, CustomStringConvertible {
+  case host(HostPlatform, BuildArchitecture)
   /// Mac Catalyst isn't a host platform, because we don't run Swift Bundler under
   /// Mac Catalyst, so it can't live under the `.host` case. But for all intents
   /// and purposes, this `.macCatalyst` case functions very similarly to `.host`.
-  case macCatalyst
+  case macCatalyst(BuildArchitecture)
   case connected(ConnectedDevice)
 
   var description: String {
     switch self {
-      case .host(let platform):
-        return "\(platform.platform.name) host machine"
-      case .macCatalyst:
-        return "Mac Catalyst host machine"
+      case .host(let platform, let architecture):
+        return "\(platform.platform.name) host machine (arch: \(architecture.rawValue))"
+      case .macCatalyst(let architecture):
+        return "Mac Catalyst host machine (arch: \(architecture.rawValue))"
       case .connected(let device):
         return "\(device.name) (\(device.platform.platform), id: \(device.id))"
     }
   }
 
+  /// The device's id (as decided by the device's corresponding management tool
+  /// such as devicectl or adb).
   var id: String? {
     switch self {
       case .host, .macCatalyst:
@@ -30,9 +32,10 @@ enum Device: Equatable, CustomStringConvertible {
     }
   }
 
+  /// The device's platform.
   var platform: Platform {
     switch self {
-      case .host(let platform):
+      case .host(let platform, _):
         return platform.platform
       case .macCatalyst:
         return .macCatalyst
@@ -41,25 +44,37 @@ enum Device: Equatable, CustomStringConvertible {
     }
   }
 
+  /// The device's architecture.
+  var architecture: BuildArchitecture {
+    switch self {
+      case .host(_, let architecture), .macCatalyst(let architecture):
+        return architecture
+      case .connected(let device):
+        return device.architecture
+    }
+  }
+
   init(
     applePlatform platform: ApplePlatform,
     name: String,
     id: String,
-    status: ConnectedDevice.Status
+    status: ConnectedDevice.Status,
+    architecture: BuildArchitecture
   ) {
     switch platform.partitioned {
       case .macOS:
         // We assume that we only have one macOS destination so we ignore the
         // device id.
-        self = .host(.macOS)
+        self = .host(.macOS, architecture)
       case .macCatalyst:
-        self = .macCatalyst
+        self = .macCatalyst(architecture)
       case .other(let nonMacPlatform):
         self.init(
           nonMacApplePlatform: nonMacPlatform,
           name: name,
           id: id,
-          status: status
+          status: status,
+          architecture: architecture
         )
     }
   }
@@ -68,13 +83,15 @@ enum Device: Equatable, CustomStringConvertible {
     nonMacApplePlatform platform: NonMacApplePlatform,
     name: String,
     id: String,
-    status: ConnectedDevice.Status
+    status: ConnectedDevice.Status,
+    architecture: BuildArchitecture
   ) {
     let device = ConnectedDevice(
       platform: platform,
       name: name,
       id: id,
-      status: status
+      status: status,
+      architecture: architecture
     )
     self = .connected(device)
   }

--- a/Sources/SwiftBundler/Bundler/Runner/Runner.swift
+++ b/Sources/SwiftBundler/Bundler/Runner/Runner.swift
@@ -24,7 +24,7 @@ enum Runner {
     log.info("Running '\(bundlerOutput.bundle.lastPathComponent)'")
 
     switch device {
-      case .host(let platform):
+      case .host(let platform, let architecture):
         guard let bundlerOutput = RunnableBundlerOutputStructure(bundlerOutput) else {
           throw Error(.missingExecutable(device, bundlerOutput))
         }
@@ -37,12 +37,30 @@ enum Runner {
               environmentVariables: environmentVariables
             )
           case .linux:
+            guard architecture == .host else {
+              throw Error(cause: InvariantFailure(
+                """
+                Invariant failure: Runner received device with unsupported \
+                architecture '\(architecture.rawValue)' (host architecture: \
+                \(BuildArchitecture.host.rawValue))
+                """
+              ))
+            }
             try await runLinuxAppOnHost(
               bundlerOutput: bundlerOutput,
               arguments: arguments,
               environmentVariables: environmentVariables
             )
           case .windows:
+            guard architecture == .host else {
+              throw Error(cause: InvariantFailure(
+                """
+                Invariant failure: Runner received device with unsupported \
+                architecture '\(architecture.rawValue)' (host architecture: \
+                \(BuildArchitecture.host.rawValue))
+                """
+              ))
+            }
             try await runWindowsAppOnHost(
               bundlerOutput: bundlerOutput,
               arguments: arguments,

--- a/Sources/SwiftBundler/Bundler/SimulatorManager/Simulator.swift
+++ b/Sources/SwiftBundler/Bundler/SimulatorManager/Simulator.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct Simulator {
+struct Simulator: Sendable, Equatable {
   var id: String
   var name: String
   var isAvailable: Bool
@@ -14,7 +14,8 @@ struct Simulator {
       id: id,
       status: isAvailable
         ? (isBooted ? .available : .summonable)
-        : .unavailable(message: "unavailable")
+        : .unavailable(message: "unavailable"),
+      architecture: .host
     )
   }
 }

--- a/Sources/SwiftBundler/Bundler/SwiftPackageManager/ApplePlatform.swift
+++ b/Sources/SwiftBundler/Bundler/SwiftPackageManager/ApplePlatform.swift
@@ -40,10 +40,24 @@ enum ApplePlatform: String, CaseIterable {
     }
   }
 
-  /// Whether the platform uses the host architecture or not. Simulators
-  /// and Mac Catalyst use the host architecture.
-  var usesHostArchitecture: Bool {
-    isSimulator || self == .macCatalyst
+  /// Architectures supported when targeting the platform.
+  var supportedArchitectures: [BuildArchitecture] {
+    switch partitioned {
+      case .macOS, .macCatalyst, .other(.simulator(_)):
+        [.arm64, .x86_64]
+      case .other(.physical(_)):
+        [.arm64]
+    }
+  }
+
+  /// Gets the default architecture to use when building for the platform.
+  func defaultTargetArchitecture(hostArchitecture: BuildArchitecture) -> BuildArchitecture {
+    switch partitioned {
+      case .macOS, .macCatalyst, .other(.simulator(_)):
+        hostArchitecture
+      case .other(.physical(_)):
+        .arm64
+    }
   }
 
   /// Whether the platform is a simulator or not.

--- a/Sources/SwiftBundler/Bundler/SwiftPackageManager/BuildArchitecture.swift
+++ b/Sources/SwiftBundler/Bundler/SwiftPackageManager/BuildArchitecture.swift
@@ -7,9 +7,9 @@ enum BuildArchitecture: String, CaseIterable, ExpressibleByArgument {
   case arm64
 
   #if arch(x86_64)
-    static let current: BuildArchitecture = .x86_64
+    static let host: BuildArchitecture = .x86_64
   #elseif arch(arm64)
-    static let current: BuildArchitecture = .arm64
+    static let host: BuildArchitecture = .arm64
   #endif
 
   var defaultValueDescription: String {

--- a/Sources/SwiftBundler/Bundler/SwiftPackageManager/Platform.swift
+++ b/Sources/SwiftBundler/Bundler/SwiftPackageManager/Platform.swift
@@ -72,6 +72,26 @@ enum Platform: String, CaseIterable {
     }
   }
 
+  /// Architectures supported when targeting the platform.
+  var supportedArchitectures: [BuildArchitecture] {
+    switch partitioned {
+      case .apple(let applePlatform):
+        applePlatform.supportedArchitectures
+      case .linux, .windows:
+        [.x86_64, .arm64]
+    }
+  }
+
+  /// Gets the default architecture to use when building for the platform.
+  func defaultTargetArchitecture(hostArchitecture: BuildArchitecture) -> BuildArchitecture {
+    switch partitioned {
+      case .apple(let applePlatform):
+        applePlatform.defaultTargetArchitecture(hostArchitecture: hostArchitecture)
+      case .linux, .windows:
+        hostArchitecture
+    }
+  }
+
   /// The platform's name.
   var name: String {
     return rawValue
@@ -113,17 +133,6 @@ enum Platform: String, CaseIterable {
         return "linux"
       case .windows:
         return "windows"
-    }
-  }
-
-  /// Whether the platform uses the host architecture or not. Simulators
-  /// and Mac Catalyst use the host architecture.
-  var usesHostArchitecture: Bool {
-    switch partitioned {
-      case .apple(let applePlatform):
-        applePlatform.usesHostArchitecture
-      case .linux, .windows:
-        true
     }
   }
 

--- a/Sources/SwiftBundler/Bundler/SwiftPackageManager/SwiftPackageManager.swift
+++ b/Sources/SwiftBundler/Bundler/SwiftPackageManager/SwiftPackageManager.swift
@@ -229,10 +229,15 @@ enum SwiftPackageManager {
         guard let platformVersion = buildContext.genericContext.platformVersion else {
           throw Error(.missingDarwinPlatformVersion(platform))
         }
-        let hostArchitecture = BuildArchitecture.current
 
+        let architectures = buildContext.genericContext.architectures
+        guard architectures.count == 1 else {
+          throw Error(.swiftPMDoesntSupportUniversalBuildsForPlatform(platform, architectures))
+        }
+
+        let architecture = architectures[0]
         let targetTriple = platform.targetTriple(
-          withArchitecture: platform.usesHostArchitecture ? hostArchitecture : .arm64,
+          withArchitecture: architecture,
           andPlatformVersion: platformVersion
         )
 

--- a/Sources/SwiftBundler/Bundler/SwiftPackageManager/SwiftPackageManagerError.swift
+++ b/Sources/SwiftBundler/Bundler/SwiftPackageManager/SwiftPackageManagerError.swift
@@ -22,6 +22,7 @@ extension SwiftPackageManager {
     case missingDarwinPlatformVersion(Platform)
     case failedToGetToolsVersion
     case invalidToolsVersion(String)
+    case swiftPMDoesntSupportUniversalBuildsForPlatform(Platform, [BuildArchitecture])
 
     var userFriendlyMessage: String {
       switch self {
@@ -63,6 +64,15 @@ extension SwiftPackageManager {
           return "Failed to get Swift package manifest tools version"
         case .invalidToolsVersion(let version):
           return "Invalid Swift tools version '\(version)' (expected a semantic version)"
+        case .swiftPMDoesntSupportUniversalBuildsForPlatform(let platform, let architectures):
+          // This should only be possible if the user has provided '--no-xcodebuild',
+          // so the error message should be pretty clear to users what they've done.
+          let clause = platform.isSimulator ? " without xcodebuild" : ""
+          return """
+            Swift Bundler cannot perform universal builds targeting \
+            \(platform.displayName)\(clause); multi-architecture build requested \
+            for \(architectures.map(\.rawValue).joinedGrammatically())
+            """
       }
     }
   }

--- a/Sources/SwiftBundler/Bundler/Xcodebuild/XcodebuildError.swift
+++ b/Sources/SwiftBundler/Bundler/Xcodebuild/XcodebuildError.swift
@@ -9,6 +9,13 @@ extension Xcodebuild {
     case failedToRunXcodebuild(command: String)
     case unsupportedPlatform(_ platform: Platform)
     case failedToMoveInterferingScheme(URL, destination: URL)
+    case unsupportedArchitecture(ApplePlatform, BuildArchitecture)
+    case universalBuildIncompatibleWithConcreteDestination
+    case failedToLocateSuitableDestinationSimulator(
+      [Simulator],
+      AppleOS,
+      BuildArchitecture
+    )
 
     var userFriendlyMessage: String {
       switch self {
@@ -25,6 +32,29 @@ extension Xcodebuild {
             Failed to temporarily relocate Xcode scheme at '\(relativePath)' which \
             would otherwise interfere with the build process. Move it manually \
             and try again.
+            """
+        case .unsupportedArchitecture(let platform, let architecture):
+          return """
+            Architecture '\(architecture.rawValue)' isn't supported when targeting \
+            '\(platform.platform.displayName)'
+            """
+        case .universalBuildIncompatibleWithConcreteDestination:
+          return """
+            A universal build was requested, but a destination device/simulator was
+            also provided. Cannot build for multiple architectures when targeting a
+            specific device.
+            """
+        case .failedToLocateSuitableDestinationSimulator(
+          _,
+          let os,
+          let architecture
+        ):
+          return """
+            Failed to locate suitable destination simulator with os \
+            '\(os.name)' and architecture '\(architecture.rawValue)'. \
+            xcodebuild requires that Swift Bundler provides a destination simulator \
+            for single-architecture simulator builds. Run 'swift bundler simulators \
+            list' to see available devices.
             """
       }
     }

--- a/Sources/SwiftBundler/Commands/BundleArguments.swift
+++ b/Sources/SwiftBundler/Commands/BundleArguments.swift
@@ -75,7 +75,7 @@ struct BundleArguments: ParsableArguments {
     parsing: .singleValue,
     help: {
       let possibleValues = BuildArchitecture.possibleValuesDescription
-      let defaultValue = BuildArchitecture.current.rawValue
+      let defaultValue = BuildArchitecture.host.rawValue
       return "The architectures to build for \(possibleValues). (default: [\(defaultValue)])"
     }(),
     transform: { string in

--- a/Sources/SwiftBundler/Utility/InvariantFailure.swift
+++ b/Sources/SwiftBundler/Utility/InvariantFailure.swift
@@ -1,0 +1,13 @@
+import ErrorKit
+
+/// An error representing a failed invariant. We use this to keep invaraint
+/// failures separate from errors. Invariant failures are generally a lot less
+/// likely to be presented to users, so making an additional error enum case
+/// for each invariant that we'd like to enforce would be a wast of time.
+struct InvariantFailure: Throwable {
+  var userFriendlyMessage: String
+
+  init(_ message: String) {
+    userFriendlyMessage = message
+  }
+}


### PR DESCRIPTION
For context, we build with xcodebuild when passed the `--xcodebuild` flag, or when targeting a non-macOS Apple platform (such as iOS) without the `--no-xcodebuild` flag. This is the default behaviour because SwiftPM has bugs related to cross-compiling for such platforms.

---

This PR fixes our handling of target architectures when building with xcodebuild, at least, it does so as best as I could within the constraints of xcodebuild.

When building a Swift package with xcodebuild, it requires the `-destination` argument to be provided. This significantly limits us when setting the target architecture, because `-destination` is incompatible with `-arch`.

The most important code changes are in `Xcodebuild.computeDestinationSpecifier`, which is where we now compute the value to parse to xcodebuild's `-destination` option. It's heavily commented with explanations for each branch, so I'll omit detailed explanation from this description.

---

In addition to fixing #126, I've updated `BundleCommand.validateArguments` to log warnings/errors in certain cases where xcodebuild and SwiftPM have known issues. As annoying as those underlying issues are, there's not much that we can do about them for now.

---

## Working examples

```sh
# Uses a generic xcodebuild destination under the hood. Works cause iOS only supports a single architecture.
sbun bundle --platform iOS

# Locates a suitable simulator to use as a destination and uses that. Doesn't use a generic build because that performs a universal build
sbun bundle --platform iOSSimulator
sbun bundle --platform iOSSimulator --arch x86_64

# Uses the generic xcodebuild 'Any iOS Simulator' destination.
sbun bundle --platform iOSSimulator --universal

# Uses the generic xcodebuild 'Any Mac' destination.
sbun bundle --platform macOS --universal --xcodebuild

# Uses SwiftPM to cross-compile; works as expected
sbun bundle --platform macOS --arch x86_64
```

## Unsupported usage

```sh
# Often fails due to xcodebuild confusing macro architectures (this is a bug in xcodebuild afaict)
sbun bundle --platform macOS --arch x86_64 --xcodebuild

# Often fails due to a bug in SwiftPM; it confuses language modes
sbun bundle --platform macOS --universal
```