### PR TITLE
Fix visionOS minimum supported version (fixes #109)

### DIFF
--- a/Sources/SwiftBundler/Bundler/SwiftPackageManager/ApplePlatform.swift
+++ b/Sources/SwiftBundler/Bundler/SwiftPackageManager/ApplePlatform.swift
@@ -136,7 +136,7 @@ enum ApplePlatform: String, CaseIterable {
       case .iOS, .iOSSimulator:
         return "7.0"
       case .visionOS, .visionOSSimulator:
-        return "0.0"
+        return "1.0"
       case .tvOS, .tvOSSimulator:
         return "9.0"
     }


### PR DESCRIPTION
Pretty simple fix. Not sure why `0.0` was used in the first place, although it does seem to work on my machine that doesn't have the visionOS runtime installed, so maybe the issue is SDK-specific? For now I've just bumped it up to 1.0 which seems sensible