### PR TITLE
Fix platform(...Simulator) condition parsing

### DIFF
--- a/Sources/SwiftBundler/Configuration/ConfigurationOverlay.swift
+++ b/Sources/SwiftBundler/Configuration/ConfigurationOverlay.swift
@@ -124,7 +124,11 @@ enum OverlayCondition: Codable, Hashable, CustomStringConvertible {
       Parse {
         "platform("
         OneOf {
-          for platform in Platform.allCases {
+          // We go through in reverse, because we need to try parsing
+          // simulator platforms before their underlying platforms, otherwise
+          // iOSSimulator matches iOS and then Swift Parsing expects the second
+          // capital S to be a closing parenthesis
+          for platform in Platform.allCases.reversed() {
             platform.rawValue.map {
               platform
             }

--- a/Tests/SwiftBundlerTests/SwiftBundlerTests.swift
+++ b/Tests/SwiftBundlerTests/SwiftBundlerTests.swift
@@ -25,6 +25,18 @@ struct Tests {
     )
   }
 
+  @Test func testConditionParsingRoundTripping() async throws {
+    let conditions =
+      Platform.allCases.map(\.rawValue).map(OverlayCondition.platform)
+        + BundlerChoice.allCases.map(\.rawValue).map(OverlayCondition.bundler)
+
+    for condition in conditions {
+      let encoded = try JSONEncoder().encode(condition)
+      let decoded = try JSONDecoder().decode(OverlayCondition.self, from: encoded)
+      #expect(condition == decoded)
+    }
+  }
+
   @Test func testCreationWorkflow() async throws {
     let directory = FileManager.default.temporaryDirectory
       .appendingPathComponent("HelloWorld")


### PR DESCRIPTION
This PR makes it possible to use `platform(...)` conditions with Apple simulator platforms. Previously wasn't possible as explained in the comment added to ConfigurationOverlay.