### PR TITLE
Ignore stderr when retrieving products dir (fixes 159)

### DIFF
--- a/Sources/SwiftBundler/Bundler/SwiftPackageManager/SwiftPackageManager.swift
+++ b/Sources/SwiftBundler/Bundler/SwiftPackageManager/SwiftPackageManager.swift
@@ -386,7 +386,7 @@ enum SwiftPackageManager {
     )
 
     do {
-      let output = try await process.getOutput()
+      let output = try await process.getOutput(excludeStdError: true)
       return URL(fileURLWithPath: output.trimmingCharacters(in: .newlines))
     } catch {
       throw Error(


### PR DESCRIPTION
The underlying issue was that Swift emits warnings every time that it's invoked on Asahi Linux, and we weren't ignoring stderr when retrieving the SwiftPM products directory, leading to the warning getting included in the products directory. Fixes #159.