### PR TITLE
Windows(ico): Switch from Lanczos resampling to linear (impl was buggy)

### DIFF
--- a/Sources/SwiftBundler/Bundler/GenericWindowsBundler.swift
+++ b/Sources/SwiftBundler/Bundler/GenericWindowsBundler.swift
@@ -159,8 +159,12 @@ enum GenericWindowsBundler: Bundler {
       return try Image<RGBA>.load(from: Array(imageData))
     }.convert(to: ARGB.self)
 
+    // NB: If we put the images in order of decreasing size instead of
+    //   increasing size then the Apps & features screen doesn't show
+    //   MSI icons correctly (it shows them blank).
     let scaledImages = [16, 24, 32, 48, 256].map { dimension in
-      image.lanczosResample(toWidth: dimension, height: dimension)
+      // TODO(stackotter): Support upscaling?
+      image.linearlyDownscale(toWidth: dimension, height: dimension)
     }
 
     let ico = Ico(images: scaledImages)


### PR DESCRIPTION
This makes Windows icons look a bit better in their downscaled versions. My Lanczos resampling implementation is buggy so I switched to a simpler linear resampling algorithm (which still has its downsides, such as its lack of alpha handling causing darkening around the edges of icons with transparent backgrounds).