### PR TITLE
MSI: Allow users to specify custom WXS file entries

### DIFF
--- a/Sources/SwiftBundler/Bundler/MSIBundler.swift
+++ b/Sources/SwiftBundler/Bundler/MSIBundler.swift
@@ -243,7 +243,8 @@ enum MSIBundler: Bundler {
             ),
           ]
         )
-      ]
+      ],
+      additionalChildren: appConfiguration.msi?.wxsExtras ?? []
     )
 
     return WXSFile(

--- a/Sources/SwiftBundler/Bundler/WXSFile.swift
+++ b/Sources/SwiftBundler/Bundler/WXSFile.swift
@@ -5,7 +5,7 @@ extension MSIBundler {
   /// This isn't intended to be used to parse or produce arbitrary WXS files.
   /// Notably we have a lot of non-nullable properties that in reality are
   /// nullable from WiX's point of view.
-  struct WXSFile: Codable {
+  struct WXSFile: Encodable {
     @Attribute var xmlns: String
     @Element var package: Package
 
@@ -39,21 +39,35 @@ extension MSIBundler {
       @Element var installUISequences: [InstallUISequence]
       @Element var installExecuteSequences: [InstallExecuteSequence]
 
-      enum CodingKeys: String, CodingKey {
-        case language = "Language"
-        case manufacturer = "Manufacturer"
-        case name = "Name"
-        case upgradeCode = "UpgradeCode"
-        case version = "Version"
-        case majorUpgrade = "MajorUpgrade"
-        case mediaTemplate = "MediaTemplate"
-        case icons = "Icon"
-        case properties = "Property"
-        case standardDirectories = "StandardDirectory"
-        case componentGroups = "ComponentGroup"
-        case customActions = "CustomAction"
-        case installUISequences = "InstallUISequence"
-        case installExecuteSequences = "InstallExecuteSequence"
+      var additionalAttributes: [String: String]
+      var additionalChildren: [WXSValue]
+
+      struct CodingKeys: OpenCodingKey {
+        static let language = Self("Language")
+        static let manufacturer = Self("Manufacturer")
+        static let name = Self("Name")
+        static let upgradeCode = Self("UpgradeCode")
+        static let version = Self("Version")
+        static let majorUpgrade = Self("MajorUpgrade")
+        static let mediaTemplate = Self("MediaTemplate")
+        static let icons = Self("Icon")
+        static let properties = Self("Property")
+        static let standardDirectories = Self("StandardDirectory")
+        static let componentGroups = Self("ComponentGroup")
+        static let customActions = Self("CustomAction")
+        static let installUISequences = Self("InstallUISequence")
+        static let installExecuteSequences = Self("InstallExecuteSequence")
+
+        let stringValue: String
+        var intValue: Int? { nil }
+
+        init?(intValue: Int) {
+          return nil
+        }
+
+        init(_ stringValue: String) {
+          self.stringValue = stringValue
+        }
       }
 
       enum Language: String, Codable {
@@ -74,7 +88,9 @@ extension MSIBundler {
         componentGroups: [ComponentGroup] = [],
         customActions: [CustomAction] = [],
         installUISequences: [InstallUISequence] = [],
-        installExecuteSequences: [InstallExecuteSequence] = []
+        installExecuteSequences: [InstallExecuteSequence] = [],
+        additionalAttributes: [String: String] = [:],
+        additionalChildren: [WXSValue] = []
       ) {
         self._language = Attribute(language)
         self._manufacturer = Attribute(manufacturer)
@@ -90,6 +106,60 @@ extension MSIBundler {
         self._customActions = Element(customActions)
         self._installUISequences = Element(installUISequences)
         self._installExecuteSequences = Element(installExecuteSequences)
+        self.additionalAttributes = additionalAttributes
+        self.additionalChildren = additionalChildren
+      }
+
+      func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(_language, forKey: .language)
+        try container.encode(_manufacturer, forKey: .manufacturer)
+        try container.encode(_name, forKey: .name)
+        try container.encode(_upgradeCode, forKey: .upgradeCode)
+        try container.encode(_version, forKey: .version)
+        try container.encode(_majorUpgrade, forKey: .majorUpgrade)
+        try container.encode(
+          _mediaTemplate,
+          forKey: .mediaTemplate
+        )
+        try container.encode(_icons, forKey: .icons)
+        try container.encode(_properties, forKey: .properties)
+        try container.encode(
+          _standardDirectories,
+          forKey: .standardDirectories
+        )
+        try container.encode(
+          _componentGroups,
+          forKey: .componentGroups
+        )
+        try container.encode(
+          _customActions,
+          forKey: .customActions
+        )
+        try container.encode(
+          _installUISequences,
+          forKey: .installUISequences
+        )
+        try container.encode(
+          _installExecuteSequences,
+          forKey: .installExecuteSequences
+        )
+
+        let additions = WXSValueXML(value: WXSValue(
+          tag: "",
+          attributes: additionalAttributes,
+          children: additionalChildren
+        ))
+        try additions.encode(intoContainer: &container)
+      }
+
+      init(from decoder: any Decoder) throws {
+        fatalError(
+          """
+          Decodable not implemented for WXSFile.Product; conformance exists to \
+          satisfy XMLCoder.Element requirements
+          """
+        )
       }
     }
 
@@ -364,15 +434,39 @@ extension MSIBundler {
 
     struct CustomAction: Codable {
       @Attribute var id: String
-      @Attribute var property: String
-      @Attribute var value: String
+      @Attribute var property: String?
+      @Attribute var value: String?
       @Attribute var execute: Scheduling
+      @Attribute var impersonate: YesOrNo?
+      @Attribute var `return`: Return?
+      @Attribute var directory: String?
+      @Attribute var exeCommand: String?
 
-      init(id: String, property: String, value: String, execute: Scheduling) {
+      init(
+        id: String,
+        property: String? = nil,
+        value: String? = nil,
+        execute: Scheduling,
+        impersonate: YesOrNo? = nil,
+        return: Return? = nil,
+        directory: String? = nil,
+        exeCommand: String? = nil
+      ) {
         self._id = Attribute(id)
         self._property = Attribute(property)
         self._value = Attribute(value)
         self._execute = Attribute(execute)
+        self._impersonate = Attribute(impersonate)
+        self._return = Attribute(`return`)
+        self._directory = Attribute(directory)
+        self._exeCommand = Attribute(exeCommand)
+      }
+
+      enum Return: String, Codable {
+        case asyncNoWait
+        case asyncWait
+        case check
+        case ignore
       }
 
       enum Scheduling: String, Codable {
@@ -390,6 +484,10 @@ extension MSIBundler {
         case property = "Property"
         case value = "Value"
         case execute = "Execute"
+        case impersonate = "Impersonate"
+        case `return` = "Return"
+        case directory = "Directory"
+        case exeCommand = "ExeCommand"
       }
     }
 

--- a/Sources/SwiftBundler/Configuration/AppConfiguration.swift
+++ b/Sources/SwiftBundler/Configuration/AppConfiguration.swift
@@ -48,6 +48,9 @@ struct AppConfiguration: Codable {
   /// their build process.
   var dependencies: [Dependency]?
 
+  /// MSI bundler related configuration properties.
+  var msi: MSIBundlerConfiguration?
+
   /// Only available in overlays with `platform(linux)` or stronger. Sets whether
   /// Swift Bundler generates a D-Bus service file for the application or not.
   @Available(.platform("linux"))

--- a/Sources/SwiftBundler/Configuration/MSIBundlerConfiguration.swift
+++ b/Sources/SwiftBundler/Configuration/MSIBundlerConfiguration.swift
@@ -1,0 +1,36 @@
+import Foundation
+import XMLCoder
+
+@Configuration(overlayable: false)
+struct MSIBundlerConfiguration: Codable {
+  /// Additional entries to add to the app's WXS configuration file before
+  /// invoking the WiX CLI to produce the final MSI.
+  ///
+  /// For example, here's how you could set your app to auto-launch using
+  /// custom WiX actions.
+  ///
+  /// ```toml
+  /// msi.wxs_extras = [
+  ///   {
+  ///     tag = "CustomAction",
+  ///     Id = "LaunchApplication",
+  ///     Execute = "immediate",
+  ///     Impersonate = "no",
+  ///     Return = "asyncNoWait",
+  ///     Directory = "InstallFolder",
+  ///     ExeCommand = "[#MainExecutable]",
+  ///   },
+  ///   {
+  ///     tag = "InstallExecuteSequence",
+  ///     children = [
+  ///       {
+  ///         tag = "Custom",
+  ///         Action = "LaunchApplication",
+  ///         After = "InstallFinalize",
+  ///       }
+  ///     ]
+  ///   },
+  /// ]
+  /// ```
+  var wxsExtras: [WXSValue]?
+}

--- a/Sources/SwiftBundler/Configuration/OpenCodingKey.swift
+++ b/Sources/SwiftBundler/Configuration/OpenCodingKey.swift
@@ -1,0 +1,9 @@
+protocol OpenCodingKey: CodingKey {
+  init(_ stringValue: String)
+}
+
+extension OpenCodingKey {
+  init?(stringValue: String) {
+    self.init(stringValue)
+  }
+}

--- a/Sources/SwiftBundler/Configuration/WXSValue.swift
+++ b/Sources/SwiftBundler/Configuration/WXSValue.swift
@@ -1,0 +1,57 @@
+struct WXSValue: TriviallyFlattenable {
+  var tag: String
+  var attributes: [String: String]
+  var children: [WXSValue]
+}
+
+extension WXSValue: Codable {
+  struct Key: OpenCodingKey, Equatable {
+    var stringValue: String
+
+    var intValue: Int? { nil}
+
+    static let tag = Self("tag")
+    static let children = Self("children")
+
+    var isSpecial: Bool {
+      self == .tag || self == .children
+    }
+
+    init?(intValue: Int) {
+      return nil
+    }
+
+    init(_ stringValue: String) {
+      self.stringValue = stringValue
+    }
+  }
+
+  init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: Key.self)
+    self.tag = try container.decode(String.self, forKey: .tag)
+
+    if container.contains(.children) {
+      let children = try container.decode([WXSValue].self, forKey: .children)
+      self.children = children
+    } else {
+      self.children = []
+    }
+
+    var keys = container.allKeys
+    keys = keys.filter { !$0.isSpecial }
+    attributes = [:]
+    for key in keys {
+      let value = try container.decode(String.self, forKey: key)
+      attributes[key.stringValue] = value
+    }
+  }
+
+  func encode(to encoder: any Encoder) throws {
+    var container = encoder.container(keyedBy: Key.self)
+    try container.encode(tag, forKey: .tag)
+    try container.encode(children, forKey: .children)
+    for (key, value) in attributes {
+      try container.encode(value, forKey: Key(key))
+    }
+  }
+}

--- a/Sources/SwiftBundler/Configuration/WXSValueXML.swift
+++ b/Sources/SwiftBundler/Configuration/WXSValueXML.swift
@@ -1,0 +1,60 @@
+import XMLCoder
+
+/// A wrapper around ``WXSValue`` to use when encoding to XML.
+struct WXSValueXML: Encodable {
+  var value: WXSValue
+
+  struct Key: OpenCodingKey, Equatable {
+    var stringValue: String
+
+    var intValue: Int? { nil}
+
+    static let tag = Self("tag")
+    static let children = Self("children")
+
+    var isSpecial: Bool {
+      self == .tag || self == .children
+    }
+
+    init?(intValue: Int) {
+      return nil
+    }
+
+    init(_ stringValue: String) {
+      self.stringValue = stringValue
+    }
+  }
+
+  func encode(to encoder: any Encoder) throws {
+    var container = encoder.container(keyedBy: Key.self)
+    try encode(intoContainer: &container)
+  }
+
+  func encode<Key: OpenCodingKey>(
+    intoContainer container: inout KeyedEncodingContainer<Key>
+  ) throws {
+    for (key, value) in value.attributes {
+      try container.encode(Attribute(value), forKey: Key(key))
+    }
+
+    var groupedChildren: [String: [WXSValueXML]] = [:]
+    for child in value.children {
+      groupedChildren[child.tag, default: []].append(WXSValueXML(value: child))
+    }
+
+    for (tag, group) in groupedChildren {
+      try container.encode(Element(group), forKey: Key(tag))
+    }
+  }
+}
+
+extension WXSValueXML: Decodable {
+  init(from decoder: any Decoder) throws {
+    fatalError(
+      """
+      Decodable not implemented for WXSValueXML; conformance exists to \
+      satisfy XMLCoder.Element requirements
+      """
+    )
+  }
+}


### PR DESCRIPTION
This PR allows people to add extra entries to the WXS file generated by Swift Bundler when creating MSI files. The WXS file describes how the MSI file should be constructed and what actions it should perform and gets interpreted by the WiX CLI which we use to create MSIs.

For example, here's how to auto-launch an application after the MSI installer completes (which is probably useful enough for us to eventually make it a feature, but that's besides the point of the example);

```toml
msi.wxs_extras = [
  {
    tag = "CustomAction",
    Id = "LaunchApplication",
    Execute = "immediate",
    Impersonate = "no",
    Return = "asyncNoWait",
    Directory = "InstallFolder",
    ExeCommand = "[#MainExecutable]",
  },
  {
    tag = "InstallExecuteSequence",
    children = [
      {
        tag = "Custom",
        Action = "LaunchApplication",
        After = "InstallFinalize",
      }
    ]
  },
]
```