### PR TITLE
Support TOML 1.1.0 syntax in Bundler.toml files

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e96cf40c2c42ab97771ecf4c1b2896e708672e5c02f3379f8acfc1409ce0d4d6",
+  "originHash" : "51ae5a4bb0e5ccddaae5d4aaf0aca47f155a769351dc34a8ddd303b7fb4d18b4",
   "pins" : [
     {
       "identity" : "aexml",
@@ -321,8 +321,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stackotter/TOMLKit",
       "state" : {
-        "revision" : "18a7db47209b83ad969196dbc4eb4904ee9955d0",
-        "version" : "0.6.1"
+        "revision" : "fc32cb1b94aa2f8721c1585341ef723a0b4a6ab8",
+        "version" : "0.7.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,7 @@ let package = Package(
     // This fork removes the dependency on swift-syntax (which was used for
     // features we don't use) to speed up Swift Bundler release builds
     .package(url: "https://github.com/stackotter/swift-parsing", .upToNextMinor(from: "0.15.0")),
-    .package(url: "https://github.com/stackotter/TOMLKit", from: "0.6.1"),
+    .package(url: "https://github.com/stackotter/TOMLKit", from: "0.7.0"),
     .package(url: "https://github.com/onevcat/Rainbow", from: "4.0.0"),
     .package(url: "https://github.com/mxcl/Version", from: "2.0.0"),
     .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.0.0"),

--- a/Sources/SwiftBundler/SwiftBundlerErrorMapper.swift
+++ b/Sources/SwiftBundler/SwiftBundlerErrorMapper.swift
@@ -30,6 +30,10 @@ public enum SwiftBundlerErrorMapper: ErrorMapper {
           Decoding error at '\(CodingPath(context.codingPath))'; \
           \(context.debugDescription)
           """
+      case let error as TOMLKit.TOMLParseError:
+        return """
+          TOML decoding error: \(error.debugDescription)
+          """
       default:
         return nil
     }


### PR DESCRIPTION
Pretty self-explanatory. Allows trailing commas and newlines in inline tables, among other changes.

This resolves #160.