### PR TITLE
Windows code signing support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "51ae5a4bb0e5ccddaae5d4aaf0aca47f155a769351dc34a8ddd303b7fb4d18b4",
+  "originHash" : "df6aff2767f1d9fe1f7aa4ce643a65cb91a9cdac5f23bd8044a78b246e0ad243",
   "pins" : [
     {
       "identity" : "aexml",
@@ -269,15 +269,6 @@
       "state" : {
         "revision" : "558f24a4647193b5a0e2104031b71c55d31ff83a",
         "version" : "2.97.1"
-      }
-    },
-    {
-      "identity" : "swift-overture",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-overture",
-      "state" : {
-        "revision" : "7977acd7597f413717058acc1e080731249a1d7e",
-        "version" : "0.5.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -49,7 +49,6 @@ let package = Package(
     .package(url: "https://github.com/tuist/XcodeProj", from: "8.16.0"),
     .package(url: "https://github.com/yonaskolb/XcodeGen", from: "2.42.0"),
     .package(url: "https://github.com/swiftlang/swift-syntax", from: "601.0.0"),
-    .package(url: "https://github.com/pointfreeco/swift-overture", from: "0.5.0"),
     .package(url: "https://github.com/swhitty/FlyingFox", from: "0.22.0"),
     .package(url: "https://github.com/jpsim/Yams", from: "5.1.2"),
     .package(url: "https://github.com/kylef/PathKit", from: "1.0.1"),
@@ -103,7 +102,6 @@ let package = Package(
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
         .product(name: "Logging", package: "swift-log"),
         .product(name: "Parsing", package: "swift-parsing"),
-        .product(name: "Overture", package: "swift-overture"),
         .product(name: "AsyncCollections", package: "async-collections"),
         .product(name: "Mutex", package: "swift-mutex"),
         .product(

--- a/Sources/SwiftBundler/Bundler/Bundler.swift
+++ b/Sources/SwiftBundler/Bundler/Bundler.swift
@@ -96,11 +96,17 @@ struct BundlerContext {
   /// The target device if any.
   var device: Device?
 
-  /// Code signing information for bundlers that support code signing.
+  /// Code signing information for bundlers that support Darwin code signing.
   ///
   /// Exists in the generic bundler context because Swift Bundler loads codesigning
   /// context up-front to notify users of configuration issues more quickly.
-  var codeSigningContext: CodeSigningContext?
+  var darwinCodeSigningContext: DarwinCodeSigningContext?
+
+  /// Code signing information for bundlers that support Windows code signing.
+  ///
+  /// Exists in the generic bundler context because Swift Bundler loads codesigning
+  /// context up-front to notify users of configuration issues more quickly.
+  var windowsCodeSigningContext: WindowsCodeSigningContext?
 
   /// The app's built dependencies.
   var builtDependencies: [String: ProjectBuilder.BuiltProduct]
@@ -108,17 +114,29 @@ struct BundlerContext {
   /// The app's main built executable file.
   var executableArtifact: URL
 
-  /// Code signing information for bundlers that support code signing.
+  /// Code signing information for bundlers that support Darwin code signing.
   ///
   /// Exists in the generic bundler context because Swift Bundler loads codesigning
   /// context up-front to notify users of configuration issues more quickly.
-  struct CodeSigningContext {
+  struct DarwinCodeSigningContext {
     /// The identity to sign the app with.
     var identity: CodeSigningIdentity
     /// A file containing entitlements to give the app if code signing.
     var entitlements: URL?
     /// A provisioning profile provided by the user.
     var manualProvisioningProfile: URL?
+  }
+
+  /// Code signing information for bundlers that support Windows code signing.
+  ///
+  /// Exists in the generic bundler context because Swift Bundler loads codesigning
+  /// context up-front to notify users of configuration issues more quickly.
+  enum WindowsCodeSigningContext {
+    /// Sign files using Azure Artifact Signing.
+    case azureArtifactSigning(metadata: URL)
+    /// Sign files using a local code signing certificate stored in the user's
+    /// certificate store.
+    case localCertificate(identity: CodeSigningIdentity)
   }
 }
 

--- a/Sources/SwiftBundler/Bundler/Bundler.swift
+++ b/Sources/SwiftBundler/Bundler/Bundler.swift
@@ -96,11 +96,11 @@ struct BundlerContext {
   /// The target device if any.
   var device: Device?
 
-  /// Apple-specific code signing context used by bundlers that support Apple
-  /// platforms. Exists in the generic bundler context because Swift Bundler
-  /// loads codesigning context up-front to notify users of configuration
-  /// issues more quickly.
-  var darwinCodeSigningContext: DarwinCodeSigningContext?
+  /// Code signing information for bundlers that support code signing.
+  ///
+  /// Exists in the generic bundler context because Swift Bundler loads codesigning
+  /// context up-front to notify users of configuration issues more quickly.
+  var codeSigningContext: CodeSigningContext?
 
   /// The app's built dependencies.
   var builtDependencies: [String: ProjectBuilder.BuiltProduct]
@@ -108,13 +108,13 @@ struct BundlerContext {
   /// The app's main built executable file.
   var executableArtifact: URL
 
-  /// Apple-specific code signing context used by bundlers that support Apple
-  /// platforms. Exists in the generic bundler context because Swift Bundler
-  /// loads codesigning context up-front to notify users of configuration
-  /// issues more quickly.
-  struct DarwinCodeSigningContext {
+  /// Code signing information for bundlers that support code signing.
+  ///
+  /// Exists in the generic bundler context because Swift Bundler loads codesigning
+  /// context up-front to notify users of configuration issues more quickly.
+  struct CodeSigningContext {
     /// The identity to sign the app with.
-    var identity: DarwinCodeSigner.Identity
+    var identity: CodeSigningIdentity
     /// A file containing entitlements to give the app if code signing.
     var entitlements: URL?
     /// A provisioning profile provided by the user.

--- a/Sources/SwiftBundler/Bundler/Bundler.swift
+++ b/Sources/SwiftBundler/Bundler/Bundler.swift
@@ -114,7 +114,7 @@ struct BundlerContext {
   /// issues more quickly.
   struct DarwinCodeSigningContext {
     /// The identity to sign the app with.
-    var identity: CodeSigner.Identity
+    var identity: DarwinCodeSigner.Identity
     /// A file containing entitlements to give the app if code signing.
     var entitlements: URL?
     /// A provisioning profile provided by the user.

--- a/Sources/SwiftBundler/Bundler/CodeSigningIdentity.swift
+++ b/Sources/SwiftBundler/Bundler/CodeSigningIdentity.swift
@@ -1,0 +1,15 @@
+/// An identity that can be used to codesign a file.
+struct CodeSigningIdentity: CustomStringConvertible {
+  /// The identity's id, which is the SHA-1 hash of the corresponding
+  /// certificate's DER representation.
+  var id: String
+  /// This is the parsed representation of ``id``, and is the SHA-1 hash of
+  /// the corresponding certificate's DER representation.
+  var certificateSHA1: [UInt8]
+  /// The identity's display name.
+  var name: String
+
+  var description: String {
+    "'\(name)' (\(id))"
+  }
+}

--- a/Sources/SwiftBundler/Bundler/DarwinBundler.swift
+++ b/Sources/SwiftBundler/Bundler/DarwinBundler.swift
@@ -239,7 +239,7 @@ enum DarwinBundler: Bundler {
     additionalContext: Context
   ) async throws(Error) {
     try await Error.catch {
-      if let codeSigningContext = context.codeSigningContext {
+      if let codeSigningContext = context.darwinCodeSigningContext {
         try await DarwinCodeSigner.signAppBundle(
           bundle: appBundle,
           identityId: codeSigningContext.identity.id,
@@ -267,7 +267,7 @@ enum DarwinBundler: Bundler {
     for context: BundlerContext
   ) async throws(Error) -> URL? {
     // If the user provided a provisioning profile, use it
-    if let profile = context.codeSigningContext?.manualProvisioningProfile {
+    if let profile = context.darwinCodeSigningContext?.manualProvisioningProfile {
       return profile
     }
 
@@ -281,7 +281,7 @@ enum DarwinBundler: Bundler {
 
     // If the target platform requires provisioning profiles, locate or
     // generate one. This requires a code signing context.
-    guard let codeSigningContext = context.codeSigningContext else {
+    guard let codeSigningContext = context.darwinCodeSigningContext else {
       throw Error(.missingCodeSigningContextForProvisioning(device.platform.os))
     }
 

--- a/Sources/SwiftBundler/Bundler/DarwinBundler.swift
+++ b/Sources/SwiftBundler/Bundler/DarwinBundler.swift
@@ -240,7 +240,7 @@ enum DarwinBundler: Bundler {
   ) async throws(Error) {
     try await Error.catch {
       if let codeSigningContext = context.darwinCodeSigningContext {
-        try await CodeSigner.signAppBundle(
+        try await DarwinCodeSigner.signAppBundle(
           bundle: appBundle,
           identityId: codeSigningContext.identity.id,
           bundleIdentifier: context.appConfiguration.identifier,
@@ -249,7 +249,7 @@ enum DarwinBundler: Bundler {
         )
       } else {
         // Codesign using an adhoc signature
-        try await CodeSigner.signAppBundle(
+        try await DarwinCodeSigner.signAppBundle(
           bundle: appBundle,
           identityId: "-",
           bundleIdentifier: context.appConfiguration.identifier,

--- a/Sources/SwiftBundler/Bundler/DarwinBundler.swift
+++ b/Sources/SwiftBundler/Bundler/DarwinBundler.swift
@@ -239,7 +239,7 @@ enum DarwinBundler: Bundler {
     additionalContext: Context
   ) async throws(Error) {
     try await Error.catch {
-      if let codeSigningContext = context.darwinCodeSigningContext {
+      if let codeSigningContext = context.codeSigningContext {
         try await DarwinCodeSigner.signAppBundle(
           bundle: appBundle,
           identityId: codeSigningContext.identity.id,
@@ -267,7 +267,7 @@ enum DarwinBundler: Bundler {
     for context: BundlerContext
   ) async throws(Error) -> URL? {
     // If the user provided a provisioning profile, use it
-    if let profile = context.darwinCodeSigningContext?.manualProvisioningProfile {
+    if let profile = context.codeSigningContext?.manualProvisioningProfile {
       return profile
     }
 
@@ -281,7 +281,7 @@ enum DarwinBundler: Bundler {
 
     // If the target platform requires provisioning profiles, locate or
     // generate one. This requires a code signing context.
-    guard let codeSigningContext = context.darwinCodeSigningContext else {
+    guard let codeSigningContext = context.codeSigningContext else {
       throw Error(.missingCodeSigningContextForProvisioning(device.platform.os))
     }
 

--- a/Sources/SwiftBundler/Bundler/DarwinCodeSigner/DarwinCodeSigner.swift
+++ b/Sources/SwiftBundler/Bundler/DarwinCodeSigner/DarwinCodeSigner.swift
@@ -58,7 +58,7 @@ enum DarwinCodeSigner {
     platform: ApplePlatform,
     entitlements: URL?
   ) async throws(Error) {
-    log.info("Codesigning app bundle")
+    log.info("Code-signing app bundle")
 
     let librariesDirectory = bundle.appendingPathComponent("Libraries")
     if librariesDirectory.exists(withType: .directory) {

--- a/Sources/SwiftBundler/Bundler/DarwinCodeSigner/DarwinCodeSigner.swift
+++ b/Sources/SwiftBundler/Bundler/DarwinCodeSigner/DarwinCodeSigner.swift
@@ -5,7 +5,7 @@ import SwiftASN1
 import X509
 
 /// A utility for codesigning Darwin application bundles
-enum CodeSigner {
+enum DarwinCodeSigner {
   /// The path to the `codesign` tool.
   static let codesignToolPath = "/usr/bin/codesign"
   /// The path to the `security` tool.
@@ -101,7 +101,7 @@ enum CodeSigner {
 
       entitlementsFile = file
 
-      try await CodeSigner.generateEntitlementsFile(
+      try await DarwinCodeSigner.generateEntitlementsFile(
         at: file,
         for: bundle,
         identityId: identityId,

--- a/Sources/SwiftBundler/Bundler/DarwinCodeSigner/DarwinCodeSigner.swift
+++ b/Sources/SwiftBundler/Bundler/DarwinCodeSigner/DarwinCodeSigner.swift
@@ -14,22 +14,6 @@ enum DarwinCodeSigner {
   /// margin of its expiry.
   static let certificateExpiryWarningMargin: TimeInterval = 24 * 60 * 60
 
-  /// An identity that can be used to codesign a bundle.
-  struct Identity: CustomStringConvertible {
-    /// The identity's id, which is the SHA-1 hash of the corresponding
-    /// certificate's DER representation.
-    var id: String
-    /// This is the parsed representation of ``id``, and is the SHA-1 hash of
-    /// the corresponding certificate's DER representation.
-    var certificateSHA1: [UInt8]
-    /// The identity's display name.
-    var name: String
-
-    var description: String {
-      "'\(name)' (\(id))"
-    }
-  }
-
   /// Generates an iOS entitlements file.
   /// - Parameters:
   ///   - outputFile: The destination for the generated entitlements file.
@@ -168,7 +152,7 @@ enum DarwinCodeSigner {
 
   /// Enumerates the user's available codesigning identities.
   /// - Returns: An array of identities.
-  static func enumerateIdentities() async throws(Error) -> [Identity] {
+  static func enumerateIdentities() async throws(Error) -> [CodeSigningIdentity] {
     let process = Process.create(
       securityToolPath,
       arguments: ["find-identity", "-pcodesigning", "-v"]
@@ -209,14 +193,14 @@ enum DarwinCodeSigner {
       return identities
     }
 
-    let identities: [Identity]
+    let identities: [CodeSigningIdentity]
     do {
       identities = try identityListParser.parse(output)
         .map { (id, name) in
           guard let parsedId = Array(fromHex: id) else {
             throw Error(.invalidId(id))
           }
-          return Identity(id: id, certificateSHA1: parsedId, name: name)
+          return CodeSigningIdentity(id: id, certificateSHA1: parsedId, name: name)
         }
     } catch {
       throw Error(.failedToParseIdentityList, cause: error)
@@ -229,7 +213,7 @@ enum DarwinCodeSigner {
   /// a substring of an identity's display name.
   static func resolveIdentity(
     shortName: String
-  ) async throws(Error) -> Identity {
+  ) async throws(Error) -> CodeSigningIdentity {
     let identities = try await enumerateIdentities()
     let matchingIdentities = identities.filter { identity in
       identity.id == shortName || identity.name.contains(shortName)
@@ -248,7 +232,7 @@ enum DarwinCodeSigner {
   }
 
   static func loadCertificate(
-    for identity: Identity
+    for identity: CodeSigningIdentity
   ) async throws(Error) -> Certificate {
     let output: String
     do {
@@ -321,7 +305,7 @@ enum DarwinCodeSigner {
     return certificate
   }
 
-  static func getTeamIdentifier(for identity: Identity) async throws(Error) -> String {
+  static func getTeamIdentifier(for identity: CodeSigningIdentity) async throws(Error) -> String {
     let certificate = try await loadCertificate(for: identity)
 
     for element in certificate.subject {

--- a/Sources/SwiftBundler/Bundler/DarwinCodeSigner/DarwinCodeSignerError.swift
+++ b/Sources/SwiftBundler/Bundler/DarwinCodeSigner/DarwinCodeSignerError.swift
@@ -1,10 +1,10 @@
 import Foundation
 import ErrorKit
 
-extension CodeSigner {
+extension DarwinCodeSigner {
   typealias Error = RichError<ErrorMessage>
 
-  /// An error message related to ``CodeSigner``.
+  /// An error message related to ``DarwinCodeSigner``.
   enum ErrorMessage: Throwable {
     case failedToEnumerateIdentities
     case failedToParseIdentityList
@@ -13,12 +13,12 @@ extension CodeSigner {
     case failedToLoadProvisioningProfile(URL)
     case provisioningProfileMissingTeamIdentifier
     case failedToEnumerateDynamicLibraries
-    case failedToLocateSigningCertificate(CodeSigner.Identity)
+    case failedToLocateSigningCertificate(DarwinCodeSigner.Identity)
     case failedToParseSigningCertificate(pem: String)
-    case signingCertificateMissingTeamIdentifier(CodeSigner.Identity)
+    case signingCertificateMissingTeamIdentifier(DarwinCodeSigner.Identity)
     case identityShortNameNotMatched(String)
     case invalidId(String)
-    case certificateExpired(CodeSigner.Identity, notValidAfter: Date)
+    case certificateExpired(DarwinCodeSigner.Identity, notValidAfter: Date)
 
     var userFriendlyMessage: String {
       switch self {

--- a/Sources/SwiftBundler/Bundler/DarwinCodeSigner/DarwinCodeSignerError.swift
+++ b/Sources/SwiftBundler/Bundler/DarwinCodeSigner/DarwinCodeSignerError.swift
@@ -13,12 +13,12 @@ extension DarwinCodeSigner {
     case failedToLoadProvisioningProfile(URL)
     case provisioningProfileMissingTeamIdentifier
     case failedToEnumerateDynamicLibraries
-    case failedToLocateSigningCertificate(DarwinCodeSigner.Identity)
+    case failedToLocateSigningCertificate(CodeSigningIdentity)
     case failedToParseSigningCertificate(pem: String)
-    case signingCertificateMissingTeamIdentifier(DarwinCodeSigner.Identity)
+    case signingCertificateMissingTeamIdentifier(CodeSigningIdentity)
     case identityShortNameNotMatched(String)
     case invalidId(String)
-    case certificateExpired(DarwinCodeSigner.Identity, notValidAfter: Date)
+    case certificateExpired(CodeSigningIdentity, notValidAfter: Date)
 
     var userFriendlyMessage: String {
       switch self {

--- a/Sources/SwiftBundler/Bundler/DynamicLibraryBundler.swift
+++ b/Sources/SwiftBundler/Bundler/DynamicLibraryBundler.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Overture
 
 /// A utility for copying dynamic libraries into an app bundle and updating the app executable's rpaths accordingly.
 enum DynamicLibraryBundler {

--- a/Sources/SwiftBundler/Bundler/GenericWindowsBundler.swift
+++ b/Sources/SwiftBundler/Bundler/GenericWindowsBundler.swift
@@ -206,12 +206,12 @@ enum GenericWindowsBundler: Bundler {
 
     try copyExecutable(at: executableArtifact, to: structure.mainExecutable)
 
-    if let codeSigningContext = context.codeSigningContext {
+    if let codeSigningContext = context.windowsCodeSigningContext {
       log.info("Signing executable")
       try await Error.catch {
         try await WindowsCodeSigner.signFile(
           structure.mainExecutable,
-          identity: codeSigningContext.identity
+          context: codeSigningContext
         )
       }
     }
@@ -352,12 +352,12 @@ enum GenericWindowsBundler: Bundler {
         }
 
         if artifact.location.pathExtension == "exe",
-          let codeSigningContext = context.codeSigningContext
+          let codeSigningContext = context.windowsCodeSigningContext
         {
           try await Error.catch {
             try await WindowsCodeSigner.signFile(
               destination,
-              identity: codeSigningContext.identity
+              context: codeSigningContext
             )
           }
         }

--- a/Sources/SwiftBundler/Bundler/GenericWindowsBundler.swift
+++ b/Sources/SwiftBundler/Bundler/GenericWindowsBundler.swift
@@ -206,6 +206,16 @@ enum GenericWindowsBundler: Bundler {
 
     try copyExecutable(at: executableArtifact, to: structure.mainExecutable)
 
+    if let codeSigningContext = context.codeSigningContext {
+      log.info("Signing executable")
+      try await Error.catch {
+        try await WindowsCodeSigner.signFile(
+          structure.mainExecutable,
+          identity: codeSigningContext.identity
+        )
+      }
+    }
+
     try await copyDependencies(
       structure: structure,
       context: context,
@@ -339,6 +349,17 @@ enum GenericWindowsBundler: Bundler {
           )
         } catch {
           throw Error(.failedToCopyExecutableDependency(name: name), cause: error)
+        }
+
+        if artifact.location.pathExtension == "exe",
+          let codeSigningContext = context.codeSigningContext
+        {
+          try await Error.catch {
+            try await WindowsCodeSigner.signFile(
+              destination,
+              identity: codeSigningContext.identity
+            )
+          }
         }
       }
     }

--- a/Sources/SwiftBundler/Bundler/MSIBundler.swift
+++ b/Sources/SwiftBundler/Bundler/MSIBundler.swift
@@ -77,12 +77,12 @@ enum MSIBundler: Bundler {
       try await process.runAndWait()
     }
 
-    if let codeSigningContext = context.codeSigningContext {
+    if let codeSigningContext = context.windowsCodeSigningContext {
       log.info("Signing installer")
       try await Error.catch {
         try await WindowsCodeSigner.signFile(
           outputStructure.bundle,
-          identity: codeSigningContext.identity
+          context: codeSigningContext
         )
       }
     }

--- a/Sources/SwiftBundler/Bundler/MSIBundler.swift
+++ b/Sources/SwiftBundler/Bundler/MSIBundler.swift
@@ -77,6 +77,16 @@ enum MSIBundler: Bundler {
       try await process.runAndWait()
     }
 
+    if let codeSigningContext = context.codeSigningContext {
+      log.info("Signing installer")
+      try await Error.catch {
+        try await WindowsCodeSigner.signFile(
+          outputStructure.bundle,
+          identity: codeSigningContext.identity
+        )
+      }
+    }
+
     return outputStructure
   }
 

--- a/Sources/SwiftBundler/Bundler/ProvisioningProfileManager/ProvisioningProfileManager.swift
+++ b/Sources/SwiftBundler/Bundler/ProvisioningProfileManager/ProvisioningProfileManager.swift
@@ -23,7 +23,7 @@ enum ProvisioningProfileManager {
     bundleIdentifier: String,
     deviceId: String,
     deviceOS: NonMacAppleOS,
-    identity: DarwinCodeSigner.Identity
+    identity: CodeSigningIdentity
   ) async throws(Error) -> URL {
     #if SUPPORT_XCODEPROJ
       let provisioningProfile = try await locateSuitableProvisioningProfile(
@@ -59,7 +59,7 @@ enum ProvisioningProfileManager {
     bundleIdentifier: String,
     deviceId: String,
     deviceOS: NonMacAppleOS,
-    identity: DarwinCodeSigner.Identity
+    identity: CodeSigningIdentity
   ) async throws(Error) -> URL? {
     #if SUPPORT_XCODEPROJ
       let profiles = try await loadProvisioningProfiles()

--- a/Sources/SwiftBundler/Bundler/ProvisioningProfileManager/ProvisioningProfileManager.swift
+++ b/Sources/SwiftBundler/Bundler/ProvisioningProfileManager/ProvisioningProfileManager.swift
@@ -23,7 +23,7 @@ enum ProvisioningProfileManager {
     bundleIdentifier: String,
     deviceId: String,
     deviceOS: NonMacAppleOS,
-    identity: CodeSigner.Identity
+    identity: DarwinCodeSigner.Identity
   ) async throws(Error) -> URL {
     #if SUPPORT_XCODEPROJ
       let provisioningProfile = try await locateSuitableProvisioningProfile(
@@ -39,7 +39,7 @@ enum ProvisioningProfileManager {
       }
 
       let teamIdentifier = try await Error.catch {
-        try await CodeSigner.getTeamIdentifier(for: identity)
+        try await DarwinCodeSigner.getTeamIdentifier(for: identity)
       }
 
       return try await generateProvisioningProfile(
@@ -59,7 +59,7 @@ enum ProvisioningProfileManager {
     bundleIdentifier: String,
     deviceId: String,
     deviceOS: NonMacAppleOS,
-    identity: CodeSigner.Identity
+    identity: DarwinCodeSigner.Identity
   ) async throws(Error) -> URL? {
     #if SUPPORT_XCODEPROJ
       let profiles = try await loadProvisioningProfiles()

--- a/Sources/SwiftBundler/Bundler/WindowsCodeSigner.swift
+++ b/Sources/SwiftBundler/Bundler/WindowsCodeSigner.swift
@@ -10,13 +10,30 @@ enum WindowsCodeSigner {
   /// The OID for codesigning certificate usage specified in the EKU field.
   static let ekuCodeSigningOID = "1.3.6.1.5.5.7.3.3"
 
+  /// The download URL for the version of Microsoft.ArtifactSigning.Client that we use.
+  static let azureArtifactSigningNUPKG =
+    URL(string: "https://www.nuget.org/api/v2/package/Microsoft.ArtifactSigning.Client/1.0.128")!
+
+  /// Signs a file using the given code signing context. Also securely timestamps the file.
+  static func signFile(
+    _ file: URL,
+    context: BundlerContext.WindowsCodeSigningContext
+  ) async throws(Error) {
+    switch context {
+      case .azureArtifactSigning(let metadata):
+        try await signFile(file, azureArtifactSigningMetadata: metadata)
+      case .localCertificate(let identity):
+        try await signFile(file, identity: identity)
+    }
+  }
+
   /// Signs a file using the given code signing identity. Also securely timestamps the file.
   static func signFile(_ file: URL, identity: CodeSigningIdentity) async throws(Error) {
     try await Error.catch {
       try await Process.create(
         "SignTool",
         arguments: [
-          "sign", "/a",
+          "sign",
           "/fd", "SHA256",
           "/tr", "http://timestamp.digicert.com",
           "/td", "SHA256",
@@ -25,6 +42,56 @@ enum WindowsCodeSigner {
         ]
       ).runAndWait()
     }
+  }
+
+  /// Signs a file using the given code signing identity. Also securely timestamps the file.
+  static func signFile(_ file: URL, azureArtifactSigningMetadata: URL) async throws(Error) {
+    let clientDLL = try await ensureArtifactSigningDLL()
+    try await Error.catch {
+      try await Process.create(
+        "SignTool",
+        arguments: [
+          "sign",
+          "/fd", "SHA256",
+          "/tr", "http://timestamp.acs.microsoft.com",
+          "/td", "SHA256",
+          "/dlib", clientDLL.path,
+          "/dmdf", azureArtifactSigningMetadata.path,
+          file.path
+        ]
+      ).runAndWait()
+    }
+  }
+
+  /// Ensures that the Azure Artifact Signing Client dll has been downloaded,
+  /// and returns its location. Downloads the client if necessary.
+  private static func ensureArtifactSigningDLL() async throws(Error) -> URL {
+    let toolsDirectory = try Error.catch {
+      try System.getToolsDirectory()
+    }
+
+    let artifactSigningDirectory = toolsDirectory / "Azure.CodeSigning.Client"
+    let dll = artifactSigningDirectory / "bin" / "x64" / "Azure.CodeSigning.Dlib.dll"
+    if dll.exists() {
+      return dll
+    }
+
+    log.info("Downloading Azure Artifact Signing Dlib")
+    log.debug("Downloading from \(azureArtifactSigningNUPKG.absoluteString)")
+    let uuid = UUID().uuidString
+    let temp = FileManager.default.temporaryDirectory
+    let artifactSigningZip = temp / "AzureArtifactSigningClient-\(uuid).zip"
+    try Error.catch(withMessage: .failedToDownloadArtifactSigningClient) {
+      let content = try Data(contentsOf: azureArtifactSigningNUPKG)
+      try content.write(to: artifactSigningZip)
+      try FileManager.default.unzipItem(at: artifactSigningZip, to: artifactSigningDirectory)
+    }
+
+    defer {
+      try? FileManager.default.removeItem(at: artifactSigningZip)
+    }
+
+    return dll
   }
 
   /// Resolve an identity search term to a specific identity. If multiple identities match

--- a/Sources/SwiftBundler/Bundler/WindowsCodeSigner.swift
+++ b/Sources/SwiftBundler/Bundler/WindowsCodeSigner.swift
@@ -10,13 +10,56 @@ enum WindowsCodeSigner {
   /// The OID for codesigning certificate usage specified in the EKU field.
   static let ekuCodeSigningOID = "1.3.6.1.5.5.7.3.3"
 
+  /// Signs a file using the given code signing identity. Also securely timestamps the file.
+  static func signFile(_ file: URL, identity: CodeSigningIdentity) async throws(Error) {
+    try await Error.catch {
+      try await Process.create(
+        "SignTool",
+        arguments: [
+          "sign", "/a",
+          "/fd", "SHA256",
+          "/tr", "http://timestamp.digicert.com",
+          "/td", "SHA256",
+          "/sha1", identity.id,
+          file.path
+        ]
+      ).runAndWait()
+    }
+  }
+
+  /// Resolve an identity search term to a specific identity. If multiple identities match
+  /// then one of the matches is chosen using an approach that remains stable across runs.
+  static func resolveIdentity(searchTerm: String) throws -> CodeSigningIdentity {
+    let identities = try enumerateIdentities()
+    let normalizedSearchTerm = searchTerm.lowercased()
+    if let identity = identities.first(where: { $0.id.lowercased() == normalizedSearchTerm }) {
+      return identity
+    }
+
+    let matches = identities.filter { identity in
+      identity.name.lowercased().contains(normalizedSearchTerm)
+      || identity.id.lowercased().contains(normalizedSearchTerm)
+    }
+
+    guard let match = matches.first else {
+      throw Error(.identityNotFound(searchTerm))
+    }
+
+    if matches.count > 1 {
+      log.warning("Multiple identities match '\(searchTerm)', using \(match)")
+      log.debug("Matches: \(matches)")
+    }
+
+    return match
+  }
+
   /// Enumerates available signing identities in the 'CurrentUser\My' certificate store.
   ///
   /// To verify its output, you can run `certutil -v -user -store My` to list all certificates
   /// in the 'CurrentUser\My' certificate store, and then ignore any that don't have a
   /// private key, and any that have the EKU field but don't have the codesigning EKU usage
   /// identifier.
-  static func enumerateIdentities() async throws(Error) -> [DarwinCodeSigner.Identity] {
+  static func enumerateIdentities() throws(Error) -> [CodeSigningIdentity] {
     #if os(Windows)
       // Inspired by https://stackoverflow.com/a/34779140/8268001
       guard let store = CertOpenSystemStoreA(0, "MY") else {
@@ -25,19 +68,16 @@ enum WindowsCodeSigner {
       defer { CertCloseStore(store, UInt32(CERT_CLOSE_STORE_FORCE_FLAG)) }
 
       var nextCertificate = CertEnumCertificatesInStore(store, nil)
-      var identities: [DarwinCodeSigner.Identity] = []
+      var identities: [CodeSigningIdentity] = []
       while let certificatePointer = nextCertificate {
-        print("Wrap cert")
         let certificate = WinCryptCert(cert: certificatePointer)
         defer { nextCertificate = CertEnumCertificatesInStore(store, certificatePointer) }
 
-        print("Has private key")
         guard certificate.hasPrivateKey else {
           // Certificates without code signing are useless to us
           continue
         }
 
-        print("OIDs")
         if let ekuOIDs = certificate.ekuOIDs {
           // If the EKU information is present, we have to check whether the cert
           // is valid for codesigning.
@@ -46,11 +86,9 @@ enum WindowsCodeSigner {
           }
         }
 
-        print("Get hash")
         let hash = certificate.hash
-        print("Get name")
         identities.append(
-          DarwinCodeSigner.Identity(
+          CodeSigningIdentity(
             id: hash.map { byte in
               String(format: "%02X", byte)
             }.joined(separator: ""),
@@ -59,7 +97,11 @@ enum WindowsCodeSigner {
           )
         )
       }
-      return identities
+
+      return identities.sorted { first, second in
+        // Sort for a stable ordering in case of multiple matches
+        (first.name, first.id) <= (second.name, second.id)
+      }
     #else
       return []
     #endif

--- a/Sources/SwiftBundler/Bundler/WindowsCodeSigner.swift
+++ b/Sources/SwiftBundler/Bundler/WindowsCodeSigner.swift
@@ -1,0 +1,141 @@
+import Foundation
+
+#if os(Windows)
+  import WinSDK
+#endif
+
+/// A utility for codesigning Windows executables/libraries/installers. Only works
+/// on Windows.
+enum WindowsCodeSigner {
+  /// The OID for codesigning certificate usage specified in the EKU field.
+  static let ekuCodeSigningOID = "1.3.6.1.5.5.7.3.3"
+
+  /// Enumerates available signing identities in the 'CurrentUser\My' certificate store.
+  ///
+  /// To verify its output, you can run `certutil -v -user -store My` to list all certificates
+  /// in the 'CurrentUser\My' certificate store, and then ignore any that don't have a
+  /// private key, and any that have the EKU field but don't have the codesigning EKU usage
+  /// identifier.
+  static func enumerateIdentities() async throws(Error) -> [DarwinCodeSigner.Identity] {
+    #if os(Windows)
+      // Inspired by https://stackoverflow.com/a/34779140/8268001
+      guard let store = CertOpenSystemStoreA(0, "MY") else {
+        throw Error(.failedToLoadCertificateStore("MY"))
+      }
+      defer { CertCloseStore(store, UInt32(CERT_CLOSE_STORE_FORCE_FLAG)) }
+
+      var nextCertificate = CertEnumCertificatesInStore(store, nil)
+      var identities: [DarwinCodeSigner.Identity] = []
+      while let certificatePointer = nextCertificate {
+        print("Wrap cert")
+        let certificate = WinCryptCert(cert: certificatePointer)
+        defer { nextCertificate = CertEnumCertificatesInStore(store, certificatePointer) }
+
+        print("Has private key")
+        guard certificate.hasPrivateKey else {
+          // Certificates without code signing are useless to us
+          continue
+        }
+
+        print("OIDs")
+        if let ekuOIDs = certificate.ekuOIDs {
+          // If the EKU information is present, we have to check whether the cert
+          // is valid for codesigning.
+          guard ekuOIDs.contains(ekuCodeSigningOID) else {
+            continue
+          }
+        }
+
+        print("Get hash")
+        let hash = certificate.hash
+        print("Get name")
+        identities.append(
+          DarwinCodeSigner.Identity(
+            id: hash.map { byte in
+              String(format: "%02X", byte)
+            }.joined(separator: ""),
+            certificateSHA1: hash,
+            name: certificate.name
+          )
+        )
+      }
+      return identities
+    #else
+      return []
+    #endif
+  }
+
+  #if os(Windows)
+    /// A more Swifty wrapper around a wincrypt certificate structure.
+    struct WinCryptCert {
+      let cert: UnsafePointer<CERT_CONTEXT>
+
+      var hasPrivateKey: Bool {
+        let foundPrivateKey = CryptFindCertificateKeyProvInfo(cert, 0, nil)
+        return foundPrivateKey
+      }
+
+      var name: String {
+        let displayNameKey = UInt32(CERT_NAME_SIMPLE_DISPLAY_TYPE)
+        let capacity = CertGetNameStringA(cert, displayNameKey, 0, nil, nil, 0)
+        let nameBuffer = UnsafeMutableBufferPointer<CChar>.allocate(capacity: Int(capacity))
+        defer { nameBuffer.deallocate() }
+        CertGetNameStringA(cert, displayNameKey, 0, nil, nameBuffer.baseAddress, capacity)
+        return String(cString: UnsafePointer(nameBuffer.baseAddress!))
+      }
+
+      var hash: [UInt8] {
+        var hashSize: UInt32 = 0
+        if !CertGetCertificateContextProperty(cert, UInt32(CERT_HASH_PROP_ID), nil, &hashSize) {
+          log.debug("Failed to get hash of certificate '\(name)', skipping")
+          return []
+        }
+
+        return Array<UInt8>(unsafeUninitializedCapacity: Int(hashSize)) {
+            (buffer, initializedCount) in
+          let succeeded = CertGetCertificateContextProperty(
+            cert,
+            UInt32(CERT_HASH_PROP_ID),
+            buffer.baseAddress,
+            &hashSize
+          )
+          precondition(
+            succeeded,
+            "Should be unreachable; size used was returned by wincrypt itself"
+          )
+          initializedCount = Int(hashSize)
+        }
+      }
+
+      var ekuOIDs: [String]? {
+        var size = UInt32(0)
+        _ = CertGetEnhancedKeyUsage(cert, 0, nil, &size)
+        guard size > 0 else {
+          return nil
+        }
+
+        let usageData = UnsafeMutableBufferPointer<CChar>.allocate(capacity: Int(size))
+        defer { usageData.deallocate() }
+
+        return usageData.baseAddress!.withMemoryRebound(
+          to: CERT_ENHKEY_USAGE.self,
+          capacity: 1
+        ) { pointer in
+          if !CertGetEnhancedKeyUsage(cert, 0, pointer, &size) {
+            log.warning("CertGetEnhancedKeyUsage failed with well-sized buffer")
+            return []
+          }
+
+          var oids: [String] = []
+          for index in 0..<Int(pointer.pointee.cUsageIdentifier) {
+            let identifierCString = pointer.pointee.rgpszUsageIdentifier
+              .advanced(by: index).pointee!
+            let identifier = String(cString: identifierCString)
+            oids.append(identifier)
+          }
+          return oids
+        }
+      }
+    }
+  #endif
+}

--- a/Sources/SwiftBundler/Bundler/WindowsCodeSignerError.swift
+++ b/Sources/SwiftBundler/Bundler/WindowsCodeSignerError.swift
@@ -7,6 +7,7 @@ extension WindowsCodeSigner {
   enum ErrorMessage: Throwable {
     case failedToLoadCertificateStore(_ identifier: String)
     case identityNotFound(_ searchTerm: String)
+    case failedToDownloadArtifactSigningClient
 
     var userFriendlyMessage: String {
       switch self {
@@ -14,6 +15,8 @@ extension WindowsCodeSigner {
           return "Failed to load current user certificate store named '\(identifier)'"
         case .identityNotFound(let searchTerm):
           return "Code signing identity not found for search term '\(searchTerm)'"
+        case .failedToDownloadArtifactSigningClient:
+          return "Failed to download Azure Artifact Signing Client"
       }
     }
   }

--- a/Sources/SwiftBundler/Bundler/WindowsCodeSignerError.swift
+++ b/Sources/SwiftBundler/Bundler/WindowsCodeSignerError.swift
@@ -1,0 +1,17 @@
+import ErrorKit
+
+extension WindowsCodeSigner {
+  typealias Error = RichError<ErrorMessage>
+
+  /// An error message related to ``WindowsCodeSigner``.
+  enum ErrorMessage: Throwable {
+    case failedToLoadCertificateStore(_ identifier: String)
+
+    var userFriendlyMessage: String {
+      switch self {
+        case .failedToLoadCertificateStore(let identifier):
+          return "Failed to load current user certificate store named '\(identifier)'"
+      }
+    }
+  }
+}

--- a/Sources/SwiftBundler/Bundler/WindowsCodeSignerError.swift
+++ b/Sources/SwiftBundler/Bundler/WindowsCodeSignerError.swift
@@ -6,11 +6,14 @@ extension WindowsCodeSigner {
   /// An error message related to ``WindowsCodeSigner``.
   enum ErrorMessage: Throwable {
     case failedToLoadCertificateStore(_ identifier: String)
+    case identityNotFound(_ searchTerm: String)
 
     var userFriendlyMessage: String {
       switch self {
         case .failedToLoadCertificateStore(let identifier):
           return "Failed to load current user certificate store named '\(identifier)'"
+        case .identityNotFound(let searchTerm):
+          return "Code signing identity not found for search term '\(searchTerm)'"
       }
     }
   }

--- a/Sources/SwiftBundler/Commands/BundleArguments.swift
+++ b/Sources/SwiftBundler/Commands/BundleArguments.swift
@@ -159,10 +159,21 @@ struct BundleArguments: ParsableArguments {
   /// A codesigning identity to use.
   #if os(macOS) || os(Windows)
     @Option(
-      name: .customLong("identity"),
       help: "The identity to use for codesigning")
   #endif
   var identity: String?
+
+  /// The path to an Azure Artifact Signing metadata file to use instead of a
+  /// codesigning identity.
+  #if os(Windows)
+    @Option(
+      help: """
+        The path to an Azure Artifact Signing metadata file. Refer to \
+        https://learn.microsoft.com/en-us/azure/artifact-signing/how-to-signing-integrations#create-a-json-file
+        """,
+      transform: URL.init(fileURLWithPath:))
+  #endif
+  var azureArtifactSigningMetadata: URL?
 
   /// A provisioning profile to use.
   #if os(macOS)

--- a/Sources/SwiftBundler/Commands/BundleArguments.swift
+++ b/Sources/SwiftBundler/Commands/BundleArguments.swift
@@ -157,7 +157,7 @@ struct BundleArguments: ParsableArguments {
   var simulatorSpecifier: String?
 
   /// A codesigning identity to use.
-  #if os(macOS)
+  #if os(macOS) || os(Windows)
     @Option(
       name: .customLong("identity"),
       help: "The identity to use for codesigning")
@@ -177,7 +177,7 @@ struct BundleArguments: ParsableArguments {
   var provisioningProfile: URL?
 
   /// If `true`, the application will be codesigned.
-  #if os(macOS)
+  #if os(macOS) || os(Windows)
     @Flag(
       name: .customLong("codesign"),
       inversion: .prefixedNo,

--- a/Sources/SwiftBundler/Commands/BundleCommand.swift
+++ b/Sources/SwiftBundler/Commands/BundleCommand.swift
@@ -234,29 +234,36 @@ struct BundleCommand: ErrorHandledCommand {
     return true
   }
 
-  static func resolveCodesigningContext(
+  static func resolveCodeSigningContext(
     codesignArgument: Bool?,
     identityArgument: String?,
     provisioningProfile: URL?,
     entitlements: URL?,
+    azureArtifactSigningMetadata: URL?,
     platform: Platform
-  ) async throws(RichError<SwiftBundlerError>) -> BundlerContext.CodeSigningContext? {
+  ) async throws(RichError<SwiftBundlerError>) -> (
+    BundlerContext.DarwinCodeSigningContext?,
+    BundlerContext.WindowsCodeSigningContext?
+  ) {
     switch platform.partitioned {
       case .apple(let platform):
-        return try await resolveDarwinCodeSigningContext(
+        let context = try await resolveDarwinCodeSigningContext(
           codesignArgument: codesignArgument,
           identityArgument: identityArgument,
           provisioningProfile: provisioningProfile,
           entitlements: entitlements,
           platform: platform
         )
+        return (context, nil)
       case .windows:
-        return try await resolveWindowsCodeSigningContext(
+        let context = try await resolveWindowsCodeSigningContext(
           codesignArgument: codesignArgument,
           identityArgument: identityArgument,
           provisioningProfile: provisioningProfile,
-          entitlements: entitlements
+          entitlements: entitlements,
+          azureArtifactSigningMetadata: azureArtifactSigningMetadata
         )
+        return (nil, context)
       case .linux:
         // Handle unsupported platforms (just Linux now)
         let invalidArguments = [
@@ -275,10 +282,10 @@ struct BundleCommand: ErrorHandledCommand {
               )
             )
           let reason = "\(list) supported when targeting '\(platform.name)'"
-          throw RichError(SwiftBundlerError.failedToResolveCodesigningConfiguration(reason: reason))
+          throw RichError(SwiftBundlerError.failedToResolveCodeSigningConfiguration(reason: reason))
         }
 
-        return nil
+        return (nil, nil)
     }
   }
 
@@ -286,20 +293,31 @@ struct BundleCommand: ErrorHandledCommand {
     codesignArgument: Bool?,
     identityArgument: String?,
     provisioningProfile: URL?,
-    entitlements: URL?
-  ) async throws(RichError<SwiftBundlerError>) -> BundlerContext.CodeSigningContext? {
+    entitlements: URL?,
+    azureArtifactSigningMetadata: URL?
+  ) async throws(RichError<SwiftBundlerError>) -> BundlerContext.WindowsCodeSigningContext? {
     guard entitlements == nil else {
       let reason = "Code signing entitlements aren't supported on Windows"
-      throw RichError(SwiftBundlerError.failedToResolveCodesigningConfiguration(reason: reason))
+      throw RichError(SwiftBundlerError.failedToResolveCodeSigningConfiguration(reason: reason))
     }
 
     guard provisioningProfile == nil else {
       let reason = "Provisioning profiles aren't supported on Windows"
-      throw RichError(SwiftBundlerError.failedToResolveCodesigningConfiguration(reason: reason))
+      throw RichError(SwiftBundlerError.failedToResolveCodeSigningConfiguration(reason: reason))
     }
 
     guard codesignArgument == true else {
       return nil
+    }
+
+    if let azureArtifactSigningMetadata {
+      guard identityArgument == nil else {
+        let reason = "--identity is incompatible with --azure-artifact-signing-metadata"
+        throw RichError(SwiftBundlerError.failedToResolveCodeSigningConfiguration(reason: reason))
+      }
+      return BundlerContext.WindowsCodeSigningContext.azureArtifactSigning(
+        metadata: azureArtifactSigningMetadata
+      )
     }
 
     let identity: CodeSigningIdentity
@@ -317,7 +335,7 @@ struct BundleCommand: ErrorHandledCommand {
           certificate ensure that it has code signing as a valid usage listed \
           in its EKU field.
           """
-        throw RichError(SwiftBundlerError.failedToResolveCodesigningConfiguration(reason: reason))
+        throw RichError(SwiftBundlerError.failedToResolveCodeSigningConfiguration(reason: reason))
       }
       if identities.count > 1 {
         log.warning(
@@ -331,7 +349,7 @@ struct BundleCommand: ErrorHandledCommand {
       identity = match
     }
 
-    return BundlerContext.CodeSigningContext(identity: identity)
+    return BundlerContext.WindowsCodeSigningContext.localCertificate(identity: identity)
   }
 
   static func resolveDarwinCodeSigningContext(
@@ -340,7 +358,7 @@ struct BundleCommand: ErrorHandledCommand {
     provisioningProfile: URL?,
     entitlements: URL?,
     platform: ApplePlatform
-  ) async throws(RichError<SwiftBundlerError>) -> BundlerContext.CodeSigningContext? {
+  ) async throws(RichError<SwiftBundlerError>) -> BundlerContext.DarwinCodeSigningContext? {
     let codesign: Bool
     if platform.requiresProvisioningProfiles {
       if codesignArgument == nil || codesignArgument == true {
@@ -350,7 +368,7 @@ struct BundleCommand: ErrorHandledCommand {
           \(platform.platform.name) is incompatible with '--no-codesign' \
           because it requires provisioning profiles
           """
-        throw RichError(SwiftBundlerError.failedToResolveCodesigningConfiguration(reason: reason))
+        throw RichError(SwiftBundlerError.failedToResolveCodeSigningConfiguration(reason: reason))
       }
     } else {
       codesign = codesignArgument ?? false
@@ -366,7 +384,7 @@ struct BundleCommand: ErrorHandledCommand {
         let list = invalidArguments.map { "'\($0)'" }
           .joinedGrammatically(withTrailingVerb: .be)
         let reason = "\(list) invalid when not codesigning"
-        throw RichError(SwiftBundlerError.failedToResolveCodesigningConfiguration(reason: reason))
+        throw RichError(SwiftBundlerError.failedToResolveCodeSigningConfiguration(reason: reason))
       }
       return nil
     }
@@ -386,7 +404,7 @@ struct BundleCommand: ErrorHandledCommand {
           let reason = """
             No codesigning identities found. Please sign into Xcode and try again.
             """
-          throw RichError(SwiftBundlerError.failedToResolveCodesigningConfiguration(reason: reason))
+          throw RichError(SwiftBundlerError.failedToResolveCodeSigningConfiguration(reason: reason))
         }
 
         if identities.count > 1 {
@@ -396,7 +414,7 @@ struct BundleCommand: ErrorHandledCommand {
         identity = firstIdentity
       }
 
-      return BundlerContext.CodeSigningContext(
+      return BundlerContext.DarwinCodeSigningContext(
         identity: identity,
         entitlements: entitlements,
         manualProvisioningProfile: provisioningProfile
@@ -607,13 +625,15 @@ struct BundleCommand: ErrorHandledCommand {
     resolvedPlatform: Platform,
     resolvedDevice: Device? = nil
   ) async throws(RichError<SwiftBundlerError>) -> BundlerOutputStructure {
-    let resolvedCodesigningContext = try await Self.resolveCodesigningContext(
-      codesignArgument: arguments.codesign,
-      identityArgument: arguments.identity,
-      provisioningProfile: arguments.provisioningProfile,
-      entitlements: arguments.entitlements,
-      platform: resolvedPlatform
-    )
+    let (resolvedDarwinCodeSigningContext, resolveWindowsCodeSigningContext) =
+      try await Self.resolveCodeSigningContext(
+        codesignArgument: arguments.codesign,
+        identityArgument: arguments.identity,
+        provisioningProfile: arguments.provisioningProfile,
+        entitlements: arguments.entitlements,
+        azureArtifactSigningMetadata: arguments.azureArtifactSigningMetadata,
+        platform: resolvedPlatform
+      )
 
     // Time execution so that we can report it to the user.
     let (elapsed, bundlerOutputStructure) = try await Stopwatch.time { () async throws(RichError<SwiftBundlerError>) in
@@ -784,7 +804,8 @@ struct BundleCommand: ErrorHandledCommand {
         outputDirectory: appOutputDirectory,
         platform: resolvedPlatform,
         device: resolvedDevice,
-        codeSigningContext: resolvedCodesigningContext,
+        darwinCodeSigningContext: resolvedDarwinCodeSigningContext,
+        windowsCodeSigningContext: resolveWindowsCodeSigningContext,
         builtDependencies: [:],
         executableArtifact: executableArtifact
       )

--- a/Sources/SwiftBundler/Commands/BundleCommand.swift
+++ b/Sources/SwiftBundler/Commands/BundleCommand.swift
@@ -295,14 +295,14 @@ struct BundleCommand: ErrorHandledCommand {
     }
 
     do {
-      let identity: CodeSigner.Identity
+      let identity: DarwinCodeSigner.Identity
       if let identityShortName = identityArgument {
         identity = try await RichError<SwiftBundlerError>.catch {
-          try await CodeSigner.resolveIdentity(shortName: identityShortName)
+          try await DarwinCodeSigner.resolveIdentity(shortName: identityShortName)
         }
       } else {
         let identities = try await RichError<SwiftBundlerError>.catch {
-          try await CodeSigner.enumerateIdentities()
+          try await DarwinCodeSigner.enumerateIdentities()
         }
 
         guard let firstIdentity = identities.first else {

--- a/Sources/SwiftBundler/Commands/BundleCommand.swift
+++ b/Sources/SwiftBundler/Commands/BundleCommand.swift
@@ -240,30 +240,107 @@ struct BundleCommand: ErrorHandledCommand {
     provisioningProfile: URL?,
     entitlements: URL?,
     platform: Platform
-  ) async throws(RichError<SwiftBundlerError>) -> BundlerContext.DarwinCodeSigningContext? {
-    guard let platform = platform.asApplePlatform else {
-      let invalidArguments = [
-        ("--codesign", codesignArgument == true),
-        ("--identity", identityArgument != nil),
-        ("--entitlements", entitlements != nil),
-        ("--provisioning-profile", provisioningProfile != nil),
-      ].filter { $0.1 }.map { $0.0 }
+  ) async throws(RichError<SwiftBundlerError>) -> BundlerContext.CodeSigningContext? {
+    switch platform.partitioned {
+      case .apple(let platform):
+        return try await resolveDarwinCodeSigningContext(
+          codesignArgument: codesignArgument,
+          identityArgument: identityArgument,
+          provisioningProfile: provisioningProfile,
+          entitlements: entitlements,
+          platform: platform
+        )
+      case .windows:
+        return try await resolveWindowsCodeSigningContext(
+          codesignArgument: codesignArgument,
+          identityArgument: identityArgument,
+          provisioningProfile: provisioningProfile,
+          entitlements: entitlements
+        )
+      case .linux:
+        // Handle unsupported platforms (just Linux now)
+        let invalidArguments = [
+          ("--codesign", codesignArgument == true),
+          ("--identity", identityArgument != nil),
+          ("--entitlements", entitlements != nil),
+          ("--provisioning-profile", provisioningProfile != nil),
+        ].filter { $0.1 }.map { $0.0 }
 
-      guard invalidArguments.count == 0 else {
-        let list = invalidArguments.map { "'\($0)'" }
-          .joinedGrammatically(
-            withTrailingVerb: Verb(
-              singular: "isn't",
-              plural: "aren't"
+        guard invalidArguments.count == 0 else {
+          let list = invalidArguments.map { "'\($0)'" }
+            .joinedGrammatically(
+              withTrailingVerb: Verb(
+                singular: "isn't",
+                plural: "aren't"
+              )
             )
-          )
-        let reason = "\(list) supported when targeting '\(platform.name)'"
-        throw RichError(SwiftBundlerError.failedToResolveCodesigningConfiguration(reason: reason))
-      }
+          let reason = "\(list) supported when targeting '\(platform.name)'"
+          throw RichError(SwiftBundlerError.failedToResolveCodesigningConfiguration(reason: reason))
+        }
 
+        return nil
+    }
+  }
+
+  static func resolveWindowsCodeSigningContext(
+    codesignArgument: Bool?,
+    identityArgument: String?,
+    provisioningProfile: URL?,
+    entitlements: URL?
+  ) async throws(RichError<SwiftBundlerError>) -> BundlerContext.CodeSigningContext? {
+    guard entitlements == nil else {
+      let reason = "Code signing entitlements aren't supported on Windows"
+      throw RichError(SwiftBundlerError.failedToResolveCodesigningConfiguration(reason: reason))
+    }
+
+    guard provisioningProfile == nil else {
+      let reason = "Provisioning profiles aren't supported on Windows"
+      throw RichError(SwiftBundlerError.failedToResolveCodesigningConfiguration(reason: reason))
+    }
+
+    guard codesignArgument == true else {
       return nil
     }
 
+    let identity: CodeSigningIdentity
+    if let searchTerm = identityArgument {
+      identity = try RichError<SwiftBundlerError>.catch {
+        try WindowsCodeSigner.resolveIdentity(searchTerm: searchTerm)
+      }
+    } else {
+      let identities = try RichError<SwiftBundlerError>.catch {
+        try WindowsCodeSigner.enumerateIdentities()
+      }
+      guard let match = identities.first else {
+        let reason = """
+          No code signing identities found. If you created a self-signed \
+          certificate ensure that it has code signing as a valid usage listed \
+          in its EKU field.
+          """
+        throw RichError(SwiftBundlerError.failedToResolveCodesigningConfiguration(reason: reason))
+      }
+      if identities.count > 1 {
+        log.warning(
+          """
+          Found multiple code signing identities, using \(match); list all available \
+          identities using 'swift-bundler list-identities' and provide the '--identity' \
+          option to select a particular identity
+          """
+        )
+      }
+      identity = match
+    }
+
+    return BundlerContext.CodeSigningContext(identity: identity)
+  }
+
+  static func resolveDarwinCodeSigningContext(
+    codesignArgument: Bool?,
+    identityArgument: String?,
+    provisioningProfile: URL?,
+    entitlements: URL?,
+    platform: ApplePlatform
+  ) async throws(RichError<SwiftBundlerError>) -> BundlerContext.CodeSigningContext? {
     let codesign: Bool
     if platform.requiresProvisioningProfiles {
       if codesignArgument == nil || codesignArgument == true {
@@ -295,7 +372,7 @@ struct BundleCommand: ErrorHandledCommand {
     }
 
     do {
-      let identity: DarwinCodeSigner.Identity
+      let identity: CodeSigningIdentity
       if let identityShortName = identityArgument {
         identity = try await RichError<SwiftBundlerError>.catch {
           try await DarwinCodeSigner.resolveIdentity(shortName: identityShortName)
@@ -319,7 +396,7 @@ struct BundleCommand: ErrorHandledCommand {
         identity = firstIdentity
       }
 
-      return BundlerContext.DarwinCodeSigningContext(
+      return BundlerContext.CodeSigningContext(
         identity: identity,
         entitlements: entitlements,
         manualProvisioningProfile: provisioningProfile
@@ -707,7 +784,7 @@ struct BundleCommand: ErrorHandledCommand {
         outputDirectory: appOutputDirectory,
         platform: resolvedPlatform,
         device: resolvedDevice,
-        darwinCodeSigningContext: resolvedCodesigningContext,
+        codeSigningContext: resolvedCodesigningContext,
         builtDependencies: [:],
         executableArtifact: executableArtifact
       )

--- a/Sources/SwiftBundler/Commands/ListIdentitiesCommand.swift
+++ b/Sources/SwiftBundler/Commands/ListIdentitiesCommand.swift
@@ -14,14 +14,14 @@ struct ListIdentitiesCommand: ErrorHandledCommand {
   public var verbose = false
 
   func wrappedRun() async throws(RichError<SwiftBundlerError>) {
-    let identities: [DarwinCodeSigner.Identity]
+    let identities: [CodeSigningIdentity]
     if HostPlatform.hostPlatform == .macOS {
       identities = try await RichError<SwiftBundlerError>.catch {
         try await DarwinCodeSigner.enumerateIdentities()
       }
     } else if HostPlatform.hostPlatform == .windows {
-      identities = try await RichError<SwiftBundlerError>.catch {
-        try await WindowsCodeSigner.enumerateIdentities()
+      identities = try RichError<SwiftBundlerError>.catch {
+        try WindowsCodeSigner.enumerateIdentities()
       }
     } else {
       throw RichError(.codesigningNotSupported(HostPlatform.hostPlatform))

--- a/Sources/SwiftBundler/Commands/ListIdentitiesCommand.swift
+++ b/Sources/SwiftBundler/Commands/ListIdentitiesCommand.swift
@@ -14,8 +14,17 @@ struct ListIdentitiesCommand: ErrorHandledCommand {
   public var verbose = false
 
   func wrappedRun() async throws(RichError<SwiftBundlerError>) {
-    let identities = try await RichError<SwiftBundlerError>.catch {
-      try await CodeSigner.enumerateIdentities()
+    let identities: [DarwinCodeSigner.Identity]
+    if HostPlatform.hostPlatform == .macOS {
+      identities = try await RichError<SwiftBundlerError>.catch {
+        try await DarwinCodeSigner.enumerateIdentities()
+      }
+    } else if HostPlatform.hostPlatform == .windows {
+      identities = try await RichError<SwiftBundlerError>.catch {
+        try await WindowsCodeSigner.enumerateIdentities()
+      }
+    } else {
+      throw RichError(.codesigningNotSupported(HostPlatform.hostPlatform))
     }
 
     Output {

--- a/Sources/SwiftBundler/Commands/SwiftBundlerError.swift
+++ b/Sources/SwiftBundler/Commands/SwiftBundlerError.swift
@@ -12,7 +12,7 @@ enum SwiftBundlerError: Throwable {
   case failedToRemoveExistingOutputs(outputDirectory: URL)
   case invalidXcodeprojDetected
   case failedToResolveTargetDevice(reason: String)
-  case failedToResolveCodesigningConfiguration(reason: String)
+  case failedToResolveCodeSigningConfiguration(reason: String)
   case failedToCopyOutBundle
   case missingConfigurationFile(URL)
   case codesigningNotSupported(HostPlatform)
@@ -66,8 +66,8 @@ enum SwiftBundlerError: Throwable {
           """
       case .failedToResolveTargetDevice(let reason):
         return "Failed to resolve target device: \(reason)"
-      case .failedToResolveCodesigningConfiguration(let reason):
-        return "Failed to resolve codesigning configuration: \(reason)"
+      case .failedToResolveCodeSigningConfiguration(let reason):
+        return "Failed to resolve code-signing configuration: \(reason)"
       case .failedToCopyOutBundle:
         return "Failed to copy out bundle"
       case .missingConfigurationFile(let file):
@@ -77,7 +77,7 @@ enum SwiftBundlerError: Throwable {
           """
       case .codesigningNotSupported(let platform):
         return """
-          Codesigning isn't supported on \(platform.platform.displayName)
+          Code-signing isn't supported on \(platform.platform.displayName)
           """
     }
   }

--- a/Sources/SwiftBundler/Commands/SwiftBundlerError.swift
+++ b/Sources/SwiftBundler/Commands/SwiftBundlerError.swift
@@ -15,6 +15,7 @@ enum SwiftBundlerError: Throwable {
   case failedToResolveCodesigningConfiguration(reason: String)
   case failedToCopyOutBundle
   case missingConfigurationFile(URL)
+  case codesigningNotSupported(HostPlatform)
 
   var userFriendlyMessage: String {
     switch self {
@@ -73,6 +74,10 @@ enum SwiftBundlerError: Throwable {
         return """
           Could not find \(file.lastPathComponent) at standard location. Are you \
           sure that you're in the root of a Swift Bundler project?
+          """
+      case .codesigningNotSupported(let platform):
+        return """
+          Codesigning isn't supported on \(platform.platform.displayName)
           """
     }
   }


### PR DESCRIPTION
This PR introduces support for code-signing on Windows. We have two modes of operation;

## Signing with local certificates

The following command builds and signs your application with a local certificate stored in the `Current User/My` Windows certificate store.

```sh
sbun bundle --codesign --identity 'My Signing Certificate'
```

## Signing with Azure Artifact Signing

The following command builds and signs your application with an Azure Artifact Signing identity. The metadata file declares safely shareable metadata about your code signing configuration, and the Azure credentials used to connect to the signing service are loaded using standard methods described in https://learn.microsoft.com/en-us/azure/artifact-signing/how-to-signing-integrations#authentication. The method that I use is setting the `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, and `AZURE_CLIENT_SECRET` environment variables to suitable values.

```sh
sbun bundle --codesign --azure-artifact-signing-metadata ./metadata.json
```

The first time that you use Swift Bundler's Azure Artifact Signing support it will download [Microsoft.ArtifactSigning.Client](https://www.nuget.org/packages/Microsoft.ArtifactSigning.Client) (version 1.0.128).