### PR TITLE
Update to swift-argument-parser version with fix for --help (explicitly)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,7 @@ let package = Package(
     .plugin(name: "SwiftBundlerCommandPlugin", targets: ["SwiftBundlerCommandPlugin"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0"),
+    .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.7.1"),
     .package(url: "https://github.com/apple/swift-log", from: "1.5.4"),
     // This fork removes the dependency on swift-syntax (which was used for
     // features we don't use) to speed up Swift Bundler release builds


### PR DESCRIPTION
Our Package.resolved already had the fixed version of swift-argument-parser, but I figured that I should bump the version in the Package.swift to make it a bit more explicit that we want that version for desirable behaviour.