### PR TITLE
Introduce a basic error hints system

### DIFF
--- a/Sources/SwiftBundler/Commands/Config/ConfigAppsCommand.swift
+++ b/Sources/SwiftBundler/Commands/Config/ConfigAppsCommand.swift
@@ -1,0 +1,14 @@
+import ArgumentParser
+import Foundation
+
+/// The subcommand for inspecting and modifying Swift Bundler app configuration.
+struct ConfigAppsCommand: AsyncParsableCommand {
+  static var configuration = CommandConfiguration(
+    commandName: "apps",
+    abstract: "View and manage app configuration.",
+    subcommands: [
+        ConfigAppsListCommand.self,
+    ],
+    defaultSubcommand: ConfigAppsListCommand.self
+  )
+}

--- a/Sources/SwiftBundler/Commands/Config/ConfigAppsListCommand.swift
+++ b/Sources/SwiftBundler/Commands/Config/ConfigAppsListCommand.swift
@@ -1,0 +1,55 @@
+import ArgumentParser
+import Foundation
+
+/// The subcommand for listing apps in the current Swift Bundler project.
+struct ConfigAppsListCommand: ErrorHandledCommand {
+  static var configuration = CommandConfiguration(
+    commandName: "list",
+    abstract: "List apps in the current Swift Bundler project."
+  )
+
+  /// The directory containing the package to inspect.
+  @Option(
+    name: [.customShort("d"), .customLong("directory")],
+    help: "The directory containing the package to inspect.",
+    transform: URL.init(fileURLWithPath:))
+  var packageDirectory: URL?
+
+  @Flag(help: "Format command output as JSON.")
+  var json = false
+
+  @Flag(
+    name: .shortAndLong,
+    help: "Print verbose error messages.")
+  var verbose = false
+
+  func wrappedRun() async throws(RichError<SwiftBundlerError>) {
+    let configuration = try await RichError<SwiftBundlerError>.catch {
+      try await PackageConfiguration.load(
+        fromDirectory: packageDirectory ?? URL(fileURLWithPath: "."),
+        migrateConfiguration: false
+      )
+    }
+
+    let apps = configuration.apps ?? [:]
+    let appNames = apps.map(\.key).sorted()
+    let appsJSON = appNames.map { appName in
+      ["name": appName]
+    }
+
+    try DebugCommand.displayOutput(
+      appsJSON,
+      json: json
+    ) {
+      if appNames.isEmpty {
+        "No apps".italic
+      } else {
+        List {
+          for appName in appNames {
+            List.Entry(appName)
+          }
+        }
+      }
+    }
+  }
+}

--- a/Sources/SwiftBundler/Commands/ConfigCommand.swift
+++ b/Sources/SwiftBundler/Commands/ConfigCommand.swift
@@ -1,0 +1,13 @@
+import ArgumentParser
+import Foundation
+
+/// The subcommand for inspecting and modifying Swift Bundler package configuration.
+struct ConfigCommand: AsyncParsableCommand {
+  static var configuration = CommandConfiguration(
+    commandName: "config",
+    abstract: "View and manage Swift Bundler configuration.",
+    subcommands: [
+        ConfigAppsCommand.self,
+    ]
+  )
+}

--- a/Sources/SwiftBundler/Commands/DebugCommand.swift
+++ b/Sources/SwiftBundler/Commands/DebugCommand.swift
@@ -70,7 +70,7 @@ struct DebugCommand: AsyncParsableCommand {
         try SwiftSDKManager.enumerateInstalledSwiftSDKs()
       }
 
-      try displayOutput(sdks, json: json) { sdk in
+      try displayKeyedOutputList(sdks, json: json) { sdk in
         let name = "\(sdk.artifactIdentifier):\(sdk.triple)"
         return KeyedList.Entry(name.bold) {
           sdk.artifactVariant.path
@@ -98,7 +98,7 @@ struct DebugCommand: AsyncParsableCommand {
         try await SwiftToolchainManager.locateSwiftToolchains()
       }
 
-      try DebugCommand.displayOutput(toolchains, json: json) { toolchain in
+      try DebugCommand.displayKeyedOutputList(toolchains, json: json) { toolchain in
         KeyedList.Entry(toolchain.displayName.bold, toolchain.root.path)
       }
     }
@@ -131,7 +131,7 @@ struct DebugCommand: AsyncParsableCommand {
         NDKVersion(ndk: ndk, version: version)
       }
 
-      try DebugCommand.displayOutput(ndkVersions, json: json) { ndkVersion in
+      try DebugCommand.displayKeyedOutputList(ndkVersions, json: json) { ndkVersion in
         KeyedList.Entry(ndkVersion.version.description.bold, ndkVersion.ndk.path)
       }
     }
@@ -152,7 +152,7 @@ struct DebugCommand: AsyncParsableCommand {
     print(string)
   }
 
-  static func displayOutput<Item: Encodable>(
+  static func displayKeyedOutputList<Item: Encodable>(
     _ items: [Item],
     json: Bool,
     entry: (Item) -> KeyedList.Entry
@@ -167,6 +167,19 @@ struct DebugCommand: AsyncParsableCommand {
       }
 
       print(output.description)
+    }
+  }
+
+  static func displayOutput<Item: Encodable>(
+    _ items: [Item],
+    json: Bool,
+    @OutputBuilder output: () -> String
+  ) throws(RichError<SwiftBundlerError>) {
+    if json {
+      try displayJSONOutput(items)
+    } else {
+      let output = output()
+      print(output)
     }
   }
 }

--- a/Sources/SwiftBundler/Commands/ErrorHandledCommand.swift
+++ b/Sources/SwiftBundler/Commands/ErrorHandledCommand.swift
@@ -22,8 +22,6 @@ extension ErrorHandledCommand {
 
 extension ErrorHandledCommand {
   func validate() {
-    // A bit of a hack to set the verbosity level whenever the verbose option is
-    // set on the root command
     if verbose {
       log.logLevel = .debug
     }
@@ -31,7 +29,7 @@ extension ErrorHandledCommand {
     do {
       try wrappedValidate()
     } catch {
-      log.error("\(chainDescription(for: error, verbose: verbose))")
+      displayError(error, verbose: verbose, displayHints: true)
       Foundation.exit(1)
     }
   }
@@ -40,7 +38,7 @@ extension ErrorHandledCommand {
     do {
       try await wrappedRun()
     } catch {
-      log.error("\(chainDescription(for: error, verbose: verbose))")
+      displayError(error, verbose: verbose, displayHints: true)
       Foundation.exit(1)
     }
   }

--- a/Sources/SwiftBundler/Configuration/PackageConfiguration.swift
+++ b/Sources/SwiftBundler/Configuration/PackageConfiguration.swift
@@ -275,7 +275,12 @@ extension PackageConfiguration.Flat {
   ) throws(PackageConfiguration.Error) -> (name: String, app: AppConfiguration.Flat) {
     if let name = name {
       guard let selected = apps[name] else {
-        throw PackageConfiguration.Error(.noSuchApp(name))
+        throw PackageConfiguration.Error(
+          .noSuchApp(name),
+          hint: Output {
+            "Run `swift bundler config apps` to list available apps"
+          }.description
+        )
       }
       return (name: name, app: selected)
     } else if let first = apps.first, apps.count == 1 {

--- a/Sources/SwiftBundler/RichError.swift
+++ b/Sources/SwiftBundler/RichError.swift
@@ -23,6 +23,7 @@ struct Location: CustomStringConvertible {
 struct RichError<Message: Error>: Throwable, RichErrorProtocol {
   var message: Message?
   var cause: (any Error)?
+  var hint: String?
   var location: Location
 
   var erasedMessage: (any Error)? {
@@ -37,19 +38,28 @@ struct RichError<Message: Error>: Throwable, RichErrorProtocol {
   init(
     _ message: Message,
     cause: (any Error)? = nil,
+    hint: String? = nil,
     file: String = #file,
     line: Int = #line,
     column: Int = #column
   ) {
     self.message = message
     self.cause = cause
+    self.hint = hint
     self.location = Location(file: file, line: line, column: column)
   }
 
   /// Creates a rich error with an underlying cause but no message.
-  init(cause: any Error, file: String = #file, line: Int = #line, column: Int = #column) {
+  init(
+    cause: any Error,
+    hint: String? = nil,
+    file: String = #file,
+    line: Int = #line,
+    column: Int = #column
+  ) {
     self.message = nil
     self.cause = cause
+    self.hint = hint
     self.location = Location(file: file, line: line, column: column)
   }
 
@@ -60,12 +70,14 @@ struct RichError<Message: Error>: Throwable, RichErrorProtocol {
   init(
     _ message: Message?,
     cause: any Error,
+    hint: String? = nil,
     file: String = #file,
     line: Int = #line,
     column: Int = #column
   ) {
     self.message = message
     self.cause = cause
+    self.hint = hint
     self.location = Location(file: file, line: line, column: column)
   }
 
@@ -164,6 +176,7 @@ protocol RichErrorProtocol: Throwable {
   var erasedMessage: (any Error)? { get }
   var messageType: any Error.Type { get }
   var cause: (any Error)? { get }
+  var hint: String? { get }
   var location: Location { get }
 }
 
@@ -327,5 +340,29 @@ func chainDescription(for error: any Error, verbose: Bool) -> String {
     return output
   } else {
     return inlineErrorDescription(for: error, verbose: verbose)
+  }
+}
+
+func hints(containedIn error: any Error) -> [String] {
+  var currentError = error
+  var hints: [String] = []
+  while let richError = currentError as? RichErrorProtocol {
+    if let hint = richError.hint {
+      hints.append(hint)
+    }
+
+    guard let nextError = richError.cause else {
+      break
+    }
+    currentError = nextError
+  }
+  return hints
+}
+
+func displayError(_ error: any Error, verbose: Bool, displayHints: Bool) {
+  log.error("\(chainDescription(for: error, verbose: verbose))")
+  let hints = hints(containedIn: error)
+  for hint in hints {
+    log.info("\(hint)")
   }
 }

--- a/Sources/SwiftBundler/SwiftBundler.swift
+++ b/Sources/SwiftBundler/SwiftBundler.swift
@@ -18,6 +18,7 @@ public struct SwiftBundler: AsyncParsableCommand {
       CleanCommand.self,
       CreateCommand.self,
       ConvertCommand.self,
+      ConfigCommand.self,
       MigrateCommand.self,
       DevicesCommand.self,
       SimulatorsCommand.self,


### PR DESCRIPTION
These changes allow us to attach hints to rich errors. If those errors are caught at the top level of an ErrorHandlerCommand then the hints are automatically discovered and displayed as info log messages after printing the error itself.