### PR TITLE
Move 'migrate' subcommand under 'config' subcommand

### DIFF
--- a/Sources/SwiftBundler/Commands/Config/ConfigMigrateCommand.swift
+++ b/Sources/SwiftBundler/Commands/Config/ConfigMigrateCommand.swift
@@ -1,0 +1,33 @@
+import ArgumentParser
+import Foundation
+
+/// The command for migrating project config files to the latest format.
+struct ConfigMigrateCommand: ErrorHandledCommand {
+  static var configuration = CommandConfiguration(
+    commandName: "migrate",
+    abstract: "Migrate a project's config file to the latest format."
+  )
+
+  /// The directory containing the package to build.
+  @Option(
+    name: [.customShort("d"), .customLong("directory")],
+    help: "The directory containing the package to migrate.",
+    transform: URL.init(fileURLWithPath:))
+  var packageDirectory: URL?
+
+  @Flag(
+    name: .shortAndLong,
+    help: "Print verbose error messages.")
+  public var verbose = false
+
+  func wrappedRun() async throws(RichError<SwiftBundlerError>) {
+    _ = try await RichError<SwiftBundlerError>.catch {
+      try await PackageConfiguration.load(
+        fromDirectory: packageDirectory ?? URL(fileURLWithPath: "."),
+        migrateConfiguration: true
+      )
+    }
+
+    log.info("Successfully migrated configuration to the latest format.")
+  }
+}

--- a/Sources/SwiftBundler/Commands/ConfigCommand.swift
+++ b/Sources/SwiftBundler/Commands/ConfigCommand.swift
@@ -8,6 +8,7 @@ struct ConfigCommand: AsyncParsableCommand {
     abstract: "View and manage Swift Bundler configuration.",
     subcommands: [
         ConfigAppsCommand.self,
+        ConfigMigrateCommand.self,
     ]
   )
 }

--- a/Sources/SwiftBundler/Commands/ConvertCommand.swift
+++ b/Sources/SwiftBundler/Commands/ConvertCommand.swift
@@ -6,7 +6,7 @@ import TOMLKit
 struct ConvertCommand: ErrorHandledCommand {
   static var configuration = CommandConfiguration(
     commandName: "convert",
-    abstract: "Converts an xcodeproj to a Swift Bundler project."
+    abstract: "Convert an xcodeproj to a Swift Bundler project."
   )
 
   @Argument(

--- a/Sources/SwiftBundler/Commands/MigrateCommand.swift
+++ b/Sources/SwiftBundler/Commands/MigrateCommand.swift
@@ -1,33 +1,32 @@
 import ArgumentParser
 import Foundation
 
-/// The command for migrating project config files to the latest format.
-struct MigrateCommand: ErrorHandledCommand {
+/// A deprecated and hidden copy of the 'swift bundler config migrate' subcommand.
+struct MigrateCommand: AsyncParsableCommand {
   static var configuration = CommandConfiguration(
     commandName: "migrate",
-    abstract: "Migrate a project's config file to the latest format."
+    abstract: """
+      Deprecated version of 'swift bundler config migrate' provided for backwards \
+      compatibility.
+      """,
+    shouldDisplay: false
   )
 
-  /// The directory containing the package to build.
-  @Option(
-    name: [.customShort("d"), .customLong("directory")],
-    help: "The directory containing the package to build.",
-    transform: URL.init(fileURLWithPath:))
-  var packageDirectory: URL?
+  @OptionGroup
+  var wrappedCommand: ConfigMigrateCommand
 
-  @Flag(
-    name: .shortAndLong,
-    help: "Print verbose error messages.")
-  public var verbose = false
+  func validate() throws {
+    log.warning(
+      """
+      'swift bundler migrate' has been deprecated; please use 'swift bundler \
+      config migrate' instead
+      """
+    )
+    print()
+    wrappedCommand.validate()
+  }
 
-  func wrappedRun() async throws(RichError<SwiftBundlerError>) {
-    _ = try await RichError<SwiftBundlerError>.catch {
-      try await PackageConfiguration.load(
-        fromDirectory: packageDirectory ?? URL(fileURLWithPath: "."),
-        migrateConfiguration: true
-      )
-    }
-
-    log.info("Successfully migrated configuration to the latest format.")
+  func run() async throws {
+    await wrappedCommand.run()
   }
 }

--- a/Sources/SwiftBundler/Configuration/PackageConfiguration.swift
+++ b/Sources/SwiftBundler/Configuration/PackageConfiguration.swift
@@ -157,7 +157,9 @@ struct PackageConfiguration: Codable, Sendable {
   ) async throws(Error) -> PackageConfiguration {
     if mode == .readOnly {
       log.warning("'\(configurationFile.relativePath)' is outdated.")
-      log.warning("Run 'swift bundler migrate' to migrate it to the latest config format.")
+      log.warning(
+        "Run 'swift bundler config migrate' to migrate it to the latest config format."
+      )
     }
 
     let contents: String
@@ -211,7 +213,9 @@ struct PackageConfiguration: Codable, Sendable {
   ) throws(Error) -> PackageConfiguration {
     log.warning("No 'Bundler.toml' file was found, but a 'Bundle.json' file was")
     if newConfigurationFile == nil {
-      log.warning("Use 'swift bundler migrate' to update your configuration to the latest format")
+      log.warning(
+        "Use 'swift bundler config migrate' to update your configuration to the latest format"
+      )
     } else {
       log.info("Migrating 'Bundle.json' to the new configuration format")
     }


### PR DESCRIPTION
Now that we have a 'config' subcommand, it makes sense for the 'migrate' subcommand to live underneath it. It's not a common enough action to live at the top level.

I've kept around a deprecated copy of the migrate subcommand which we can probably just remove in 3.0 but it was an interesting exercise to figure out how to do so using swift-argument-parser without too much code duplication.