### PR TITLE
Fix Process.locate on Windows

### DIFF
--- a/Sources/SwiftBundler/Extensions/Process.swift
+++ b/Sources/SwiftBundler/Extensions/Process.swift
@@ -339,14 +339,27 @@ extension Process {
     }
 
     do {
-      let path = try await Process.create(
-        "/bin/sh",
-        arguments: [
-          "-c",
-          "which \(tool)",
-        ],
-        runSilentlyWhenNotVerbose: false
-      ).getOutput()
+      let path: String
+      switch HostPlatform.hostPlatform {
+        case .linux, .macOS:
+          path = try await Process.create(
+            "/bin/sh",
+            arguments: [
+              "-c",
+              "which \(tool)",
+            ],
+            runSilentlyWhenNotVerbose: false
+          ).getOutput()
+        case .windows:
+          path = try await Process.create(
+            "C:\\Windows\\System32\\cmd.exe",
+            arguments: [
+              "/c",
+              "where \(tool)",
+            ],
+            runSilentlyWhenNotVerbose: false
+          ).getOutput()
+      }
 
       return path.trimmingCharacters(in: .whitespacesAndNewlines)
     } catch {


### PR DESCRIPTION
We didn't use `Process.locate` on Windows until I implemented a Swiftly workaround rather recently. I guess I never tested that workaround on Windows, because `Process.locate` was purely focused on Unix platforms before this PR.