### PR TITLE
CI: Only push-trigger workflows for main branch (to save runners)

### DIFF
--- a/.github/workflows/swift-linux.yml
+++ b/.github/workflows/swift-linux.yml
@@ -2,7 +2,11 @@ name: Build Linux
 
 on:
   push:
+    branches:
+      - 'main'
   pull_request:
+    branches-ignore:
+      - 'gh-pages'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/swift-macos.yml
+++ b/.github/workflows/swift-macos.yml
@@ -2,7 +2,11 @@ name: Build macOS
 
 on:
   push:
+    branches:
+      - 'main'
   pull_request:
+    branches-ignore:
+      - 'gh-pages'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/swift-windows.yml
+++ b/.github/workflows/swift-windows.yml
@@ -2,7 +2,11 @@ name: Build Windows
 
 on:
   push:
+    branches:
+      - 'main'
   pull_request:
+    branches-ignore:
+      - 'gh-pages'
   workflow_dispatch:
 
 defaults:

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -2,12 +2,12 @@ name: Lint
 
 on:
   push:
-    branches-ignore:
-      - 'gh-pages'
-  
+    branches:
+      - 'main'
   pull_request:
     branches-ignore:
       - 'gh-pages'
+  workflow_dispatch:
 
 jobs:
   swift-lint:

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -2,7 +2,11 @@ name: Update Docs
 
 on:
   push:
+    branches:
+      - 'main'
   pull_request:
+    branches-ignore:
+      - 'gh-pages'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This makes it so that any pull requests made from branches within the repository don't trigger duplicate CI jobs (i.e. pull requests made by me)