### PR TITLE
Show output of swift package resolve (we were suppressing it)

### DIFF
--- a/Sources/SwiftBundler/Bundler/SwiftPackageManager/SwiftPackageManager.swift
+++ b/Sources/SwiftBundler/Bundler/SwiftPackageManager/SwiftPackageManager.swift
@@ -474,7 +474,8 @@ enum SwiftPackageManager {
       try await Process.create(
         swiftPath(toolchain: toolchain),
         arguments: ["package", "resolve"],
-        directory: packageDirectory
+        directory: packageDirectory,
+        runSilentlyWhenNotVerbose: false
       ).runAndWait()
     }
   }


### PR DESCRIPTION
Not sure why I thought it'd be a good idea to suppress that by default. SwiftPM doesn't print anything when there's nothing to do, so there's not really anything against showing the output all the time. I think I originally assumed that SwiftPM would print the whole big resolution log every time.