### PR TITLE
Windows: Fix bundling of debug builds; copy debug DLLs

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "bebdc48e3b5a35e8fe1f66fb1419ab3b37534de5927cd42fae8fee9f897240e1",
+  "originHash" : "a5d781507088a0ab0eae81f6d27c4e630e057e532441317066c8fd257bd115fd",
   "pins" : [
     {
       "identity" : "aexml",
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stackotter/ErrorKit",
       "state" : {
-        "revision" : "09fa11c7f7dfd45d8b85e73b7ddb7afabb1ff01b",
-        "version" : "2.0.0"
+        "revision" : "8144f39785e845f9a4048bdf67825f8ae53c54ac",
+        "version" : "2.1.0"
       }
     },
     {

--- a/Sources/SwiftBundler/Bundler/GenericWindowsBundler.swift
+++ b/Sources/SwiftBundler/Bundler/GenericWindowsBundler.swift
@@ -24,7 +24,7 @@ enum GenericWindowsBundler: Bundler {
   private static let resourceHackerDownloadURL =
     URL(string: "https://www.angusj.com/resourcehacker/resource_hacker.zip")!
 
-  private static let dllBundlingAllowList: [String] = [
+  static let dllBundlingAllowList: [String] = [
     "swiftCore",
     "swiftCRT",
     "swiftDispatch",
@@ -50,13 +50,17 @@ enum GenericWindowsBundler: Bundler {
     "swift_Differentiation",
     "concrt140",
     "msvcp140",
+    "msvcp140d",
     "msvcp140_1",
     "msvcp140_2",
     "msvcp140_atomic_wait",
     "msvcp140_codecvt_ids",
     "vccorlib140",
     "vcruntime140",
+    "vcruntime140d",
     "vcruntime140_1",
+    "vcruntime140_1d",
+    "ucrtbased",
     "vcruntime140_threads",
     "dispatch",
   ].map { "\($0).dll".lowercased() }
@@ -433,7 +437,8 @@ enum GenericWindowsBundler: Bundler {
 
     let dlls = try await enumerateDynamicLibraryDependencies(
       module: module,
-      productsDirectory: productsDirectory
+      productsDirectory: productsDirectory,
+      systemDLLNameAllowList: dllBundlingAllowList
     )
 
     for dll in dlls {
@@ -480,9 +485,13 @@ enum GenericWindowsBundler: Bundler {
   }
 
   /// Enumerates the non-system DLLs depended on by the given module.
-  private static func enumerateDynamicLibraryDependencies(
+  /// - Parameter dllNameAllowList: A list of allowed dll names, in lowercase.
+  ///   When not present, system DLLs depended upon by the module are
+  ///   unconditionally discovered.
+  static func enumerateDynamicLibraryDependencies(
     module: URL,
-    productsDirectory: URL
+    productsDirectory: URL,
+    systemDLLNameAllowList: [String]?
   ) async throws(Error) -> [URL] {
     let output: String
     do {
@@ -526,7 +535,18 @@ enum GenericWindowsBundler: Bundler {
       return try resolveDLL(dllName, productsDirectory: productsDirectory)
     }
 
-    return dlls
+    if let systemDLLNameAllowList {
+      // If the dll isn't a product of the SwiftPM build, we should only
+      // copy it across if it's known (cause there are many DLLs, such as
+      // ones shipped with Windows, that we shouldn't be distributing with
+      // apps).
+      return dlls.filter { dll in
+        dll.isContained(in: productsDirectory)
+        || systemDLLNameAllowList.contains(dll.lastPathComponent.lowercased())
+      }
+    } else {
+      return dlls
+    }
   }
 
   private static func resolveDLL(
@@ -540,11 +560,9 @@ enum GenericWindowsBundler: Bundler {
       return guess
     }
 
-    // If the dll isn't a product of the SwiftPM build, we should only
-    // copy it across if it's known (cause there are many DLLs, such as
-    // ones shipped with Windows, that we shouldn't be distributing with
-    // apps).
-    guard dllBundlingAllowList.contains(name.lowercased()) else {
+    if name.starts(with: "api-") || name.starts(with: "ext-") {
+      // https://learn.microsoft.com/en-us/windows/win32/apiindex/windows-apisets
+      log.debug("Ignoring virtual DLL '\(name)'")
       return nil
     }
 

--- a/Sources/SwiftBundler/Commands/DebugCommand.swift
+++ b/Sources/SwiftBundler/Commands/DebugCommand.swift
@@ -1,4 +1,5 @@
 import ArgumentParser
+import ErrorKit
 import Foundation
 import Version
 
@@ -14,6 +15,7 @@ struct DebugCommand: AsyncParsableCommand {
       ListSDKs.self,
       ListToolchains.self,
       ListAndroidNDKs.self,
+      ListWindowsDynamicDependencies.self,
     ]
   )
 
@@ -139,6 +141,77 @@ struct DebugCommand: AsyncParsableCommand {
       try DebugCommand.displayKeyedOutputList(ndkVersions, json: json) { ndkVersion in
         KeyedList.Entry(ndkVersion.version.description.bold, ndkVersion.ndk.path)
       }
+    }
+  }
+
+  struct ListWindowsDynamicDependencies: ErrorHandledCommand {
+    static var configuration = CommandConfiguration(
+      commandName: "list-windows-dynamic-dependencies",
+      abstract: """
+        List all dynamic dependencies of a Windows exe or dll file. Only \
+        supported on Windows hosts
+        """
+    )
+
+    @Argument(
+      help: "The exe or dll file to enumerate dependencies of",
+      transform: URL.init(fileURLWithPath:)
+    )
+    var module: URL
+
+    @Flag(name: .shortAndLong, help: "Print verbose error messages.")
+    var verbose = false
+
+    @Flag(name: .customLong("include-system-dlls"), help: "Include system DLLs")
+    var includeSystemDLLs = false
+
+    @Flag(help: "Display the output as JSON (includes more information)")
+    var json = false
+
+    func wrappedRun() async throws(RichError<SwiftBundlerError>) {
+      #if !os(Windows)
+        log.error("list-windows-dynamic-dependencies is only supported on Windows hosts")
+        Foundation.exit(1)
+      #else
+        let productsDirectory = module.deletingLastPathComponent()
+
+        let dependencies = try await RichError<SwiftBundlerError>.catch {
+          var queue = [module]
+          var dependencies: [URL] = []
+
+          while !queue.isEmpty {
+            let item = queue.removeFirst()
+            do {
+              let newDependencies = try await GenericWindowsBundler
+                .enumerateDynamicLibraryDependencies(
+                  module: item,
+                  productsDirectory: productsDirectory,
+                  systemDLLNameAllowList: includeSystemDLLs
+                    ? nil
+                    : GenericWindowsBundler.dllBundlingAllowList
+                )
+            
+              for dependency in newDependencies where !dependencies.contains(dependency) {
+                queue.append(dependency)
+                dependencies.append(dependency)
+              }
+            } catch {
+              log.error("Failed to resolve dependencies of \(item.path)")
+              displayError(error, verbose: verbose, displayHints: false)
+            }
+          }
+
+          return dependencies
+        }
+
+        try DebugCommand.displayOutput(dependencies.map(\.path), json: json) {
+          List {
+            for dependency in dependencies {
+              List.Entry(dependency.path)
+            }
+          }
+        }
+      #endif
     }
   }
 


### PR DESCRIPTION
This PR updates the Windows system DLL allow list to include the debug variants of certain DLLs. It also updates the DLL resolution logic to properly ignore Windows [ApiSets](https://learn.microsoft.com/en-us/windows/win32/apiindex/windows-apisets) (aka Virtual DLLs).