### PR TITLE
Initial AAPT resource support

### DIFF
--- a/Sources/SwiftBundler/Bundler/APKBundler.swift
+++ b/Sources/SwiftBundler/Bundler/APKBundler.swift
@@ -575,7 +575,7 @@ enum APKBundler: Bundler {
         // we don't care which one.
         hasLayouts = true
       }
-      let destination = resourcesDirectory / file.path(relativeTo: directory)
+      let destination = resourcesDirectory / relativePath
 
       let destinationDirectory = destination.deletingLastPathComponent()
       if !destinationDirectory.exists() {

--- a/Sources/SwiftBundler/Bundler/APKBundler.swift
+++ b/Sources/SwiftBundler/Bundler/APKBundler.swift
@@ -147,6 +147,14 @@ enum APKBundler: Bundler {
       try AndroidSDKManager.getVersion(ofNDKAt: ndk)
     }
 
+    log.info("Locating and copying Android resources")
+    let resourceCopyingResult = try copyResources(
+      dependedOnByRootProduct: context.appConfiguration.product,
+      fromPackageGraph: context.packageGraph,
+      toResources: project.resourceDirectory,
+      targetPlatform: context.platform
+    )
+
     // Create Gradle configuration files
     let packageIdentifier = computePackageIdentifier(
       forAppIdentifier: context.appConfiguration.identifier
@@ -160,7 +168,9 @@ enum APKBundler: Bundler {
       compileSDK: compileSDK,
       architectures: context.architectures,
       projectStructure: project,
-      ndkVersion: ndkVersion
+      ndkVersion: ndkVersion,
+      containsLayouts: resourceCopyingResult.hasLayouts,
+      aaptOptions: resourceCopyingResult.aaptOptions
     )
     let gradleSettings = generateGradleSettings(forApp: context.appName)
     let gradleProperties = generateGradleProperties()
@@ -406,11 +416,11 @@ enum APKBundler: Bundler {
       let javaDirectory = configuration.android?.javaDirectory
       let kotlinDirectory = configuration.android?.kotlinDirectory ?? javaDirectory
       if let javaDirectory {
-        log.info("Target '\(target.name)' has Java sources")
+        log.debug("Target '\(target.name)' has Java sources")
         directories.append((targetInfo.directory / javaDirectory, target, "java"))
       }
       if let kotlinDirectory {
-        log.info("Target '\(target.name)' has Kotlin sources")
+        log.debug("Target '\(target.name)' has Kotlin sources")
         directories.append((targetInfo.directory / kotlinDirectory, target, "kt"))
       }
     }
@@ -477,6 +487,119 @@ enum APKBundler: Bundler {
         }
       }
     }
+  }
+
+  private static func copyResources(
+    dependedOnByRootProduct product: String,
+    fromPackageGraph packageGraph: SwiftPackageManager.PackageGraph,
+    toResources resourcesDirectory: URL,
+    targetPlatform: Platform
+  ) throws(Error) -> ResourceCopyingResult {
+    let conditionalTargets = try Error.catch {
+      try packageGraph.transitiveTargets(
+        inProduct: product,
+        inPackage: packageGraph.rootPackage.reference
+      )
+    }
+
+    let targets = packageGraph.activeTargets(
+      inConditionalReferences: conditionalTargets,
+      withTargetPlatform: targetPlatform
+    )
+
+    for target in targets {
+      guard let configuration = try Error.catch(do: {
+        try packageGraph.configuration(ofTarget: target)
+      }) else {
+        continue
+      }
+      
+      let targetInfo = try Error.catch {
+        try packageGraph.target(referredToBy: target)
+      }
+
+      if configuration.android?.resourceDirectory != nil && targetInfo.kind != .executable {
+        throw Error(.unsupportedAAPTResources(target))
+      }
+    }
+
+    let target = try Error.catch {
+      try packageGraph.executableTarget(correspondingToExecutableProduct: product)
+    }
+
+    guard let configuration = try Error.catch(do: {
+      try packageGraph.configuration(ofTarget: target)
+    }) else {
+      return ResourceCopyingResult(hasLayouts: false, aaptOptions: nil)
+    }
+
+    let aaptOptions = configuration.android?.aapt
+
+    guard let resourceDirectory = configuration.android?.resourceDirectory else {
+      return ResourceCopyingResult(hasLayouts: false, aaptOptions: aaptOptions)
+    }
+
+    let targetInfo = try Error.catch {
+      try packageGraph.target(referredToBy: target)
+    }
+
+    let directory = targetInfo.directory / resourceDirectory
+
+    guard let enumerator = FileManager.default.enumerator(
+      at: directory,
+      includingPropertiesForKeys: nil
+    ) else {
+      throw Error(.failedToEnumerateAAPTResources(directory, target))
+    }
+
+    log.debug("Target '\(target.name)' has Android resources")
+
+    var files: [URL] = []
+    for item in enumerator {
+      guard
+        let file = item as? URL,
+        file.exists(withType: .file)
+      else {
+        continue
+      }
+
+      files.append(file)
+    }
+
+    var hasLayouts = false
+
+    for file in files {
+      let relativePath = file.path(relativeTo: directory)
+      if relativePath.starts(with: "./layout") {
+        // could be layout/*.xml, layout-sw600dp/*.xml, layout-land/*.xml, ...
+        // we don't care which one.
+        hasLayouts = true
+      }
+      let destination = resourcesDirectory / file.path(relativeTo: directory)
+
+      let destinationDirectory = destination.deletingLastPathComponent()
+      if !destinationDirectory.exists() {
+        try Error.catch {
+          try FileManager.default.createDirectory(
+            at: destinationDirectory,
+            withIntermediateDirectories: true
+          )
+        }
+      }
+
+      try Error.catch(
+        withMessage: .failedToCopyAAPTResource(source: file, destination: destination)
+      ) {
+        try FileManager.default.copyItem(at: file, to: destination)
+      }
+    }
+
+    return ResourceCopyingResult(hasLayouts: hasLayouts, aaptOptions: aaptOptions)
+  }
+    
+  struct ResourceCopyingResult {
+    var hasLayouts: Bool
+    var aaptOptions: TargetConfiguration.Android.AAPTOptions.Flat?
   }
 
   struct SharedObject: Hashable {
@@ -595,6 +718,31 @@ enum APKBundler: Bundler {
     return dependencies
   }
 
+  private static func escapeStringForKotlin(_ str: String) -> String {
+    // https://kotlinlang.org/docs/characters.html#escape-sequences
+    // Backslash needs to be first and replacements need to be by Unicode scalars, not characters.
+    // Single quote does not need to be escaped in double-quoted strings.
+    let replacements: [(UnicodeScalar, String.UnicodeScalarView)] = [
+      ("\\", "\\\\".unicodeScalars),
+      ("\t", "\\t".unicodeScalars),
+      ("\u{08}", "\\b".unicodeScalars),
+      ("\n", "\\n".unicodeScalars),
+      ("\r", "\\r".unicodeScalars),
+      ("\"", "\\\"".unicodeScalars),
+      ("$", "\\$".unicodeScalars),
+    ]
+
+    var result = str.unicodeScalars
+    for replacement in replacements {
+      var endIndex = result.endIndex
+      while let index = result[..<endIndex].lastIndex(of: replacement.0) {
+        result.replaceSubrange(index...index, with: replacement.1)
+        endIndex = index
+      }
+    }
+    return String(result)
+  }
+
   private static func generateGradleBuildConfig(
     packageIdentifier: String,
     appVersion: Version,
@@ -604,7 +752,9 @@ enum APKBundler: Bundler {
     compileSDK: Int,
     architectures: [BuildArchitecture],
     projectStructure: ProjectStructure,
-    ndkVersion: Version
+    ndkVersion: Version,
+    containsLayouts: Bool,
+    aaptOptions: TargetConfiguration.Android.AAPTOptions.Flat?
   ) -> String {
     let architectureNames = architectures.map(\.androidABIName)
     let abiFilters = architectureNames.map { architecture in
@@ -629,6 +779,52 @@ enum APKBundler: Bundler {
         """
     } else {
       cmake16KBAlignmentFix = ""
+    }
+
+    let buildFeatures = containsLayouts
+      ? """
+
+
+          buildFeatures {
+              viewBinding = true
+              dataBinding = true
+          }
+      """
+      : ""
+
+    var aaptOptionsString = ""
+    if let aaptOptions {
+      aaptOptionsString = "\n\n    androidResources {\n"
+      defer { aaptOptionsString += "    }" }
+
+      if !aaptOptions.ignoreAssetsPatterns.isEmpty {
+        aaptOptionsString += "        ignoreAssetsPatterns.addAll(listOf("
+        aaptOptionsString += aaptOptions.ignoreAssetsPatterns.map { "\"\(escapeStringForKotlin($0))\"" }
+          .joined(separator: ", ")
+        aaptOptionsString += "))\n"
+      }
+
+      if !aaptOptions.noCompress.isEmpty {
+        aaptOptionsString += "        noCompress.addAll(listOf("
+        aaptOptionsString += aaptOptions.noCompress.map { "\"\(escapeStringForKotlin($0))\"" }
+          .joined(separator: ", ")
+        aaptOptionsString += "))\n"
+      }
+
+      if let failOnMissingConfigEntry = aaptOptions.failOnMissingConfigEntry {
+        aaptOptionsString += "        failOnMissingConfigEntry = \(failOnMissingConfigEntry)\n"
+      }
+
+      if !aaptOptions.additionalParameters.isEmpty {
+        aaptOptionsString += "        additionalParameters.addAll(listOf("
+        aaptOptionsString += aaptOptions.additionalParameters.map { "\"\(escapeStringForKotlin($0))\"" }
+          .joined(separator: ", ")
+        aaptOptionsString += "))\n"
+      }
+
+      if let namespaced = aaptOptions.namespaced {
+        aaptOptionsString += "        namespaced = \(namespaced)\n"
+      }
     }
 
     // TODO: Make JVM target configurable
@@ -677,7 +873,7 @@ enum APKBundler: Bundler {
           compileOptions {
               sourceCompatibility = JavaVersion.VERSION_17
               targetCompatibility = JavaVersion.VERSION_17
-          }
+          }\(buildFeatures)\(aaptOptionsString)
       }
 
       kotlin {

--- a/Sources/SwiftBundler/Bundler/APKBundlerError.swift
+++ b/Sources/SwiftBundler/Bundler/APKBundlerError.swift
@@ -27,6 +27,9 @@ extension APKBundler {
     case failedToCopyAPK(_ source: URL, _ destination: URL)
     case failedToEnumerateJVMSources(_ directory: URL, SwiftPackageManager.TargetReference)
     case failedToCopyJVMSource(source: URL, destination: URL)
+    case failedToEnumerateAAPTResources(_ directory: URL, SwiftPackageManager.TargetReference)
+    case failedToCopyAAPTResource(source: URL, destination: URL)
+    case unsupportedAAPTResources(SwiftPackageManager.TargetReference)
     case cannotBundleAPKWithoutSwiftAndroidSDK
     case cannotBuildAPKWithoutTargetAndroidPlatformVersion
 
@@ -91,6 +94,22 @@ extension APKBundler {
           return """
             Failed to copy Java/Kotlin source from '\(source.path)' to \
             '\(destination.path)'
+            """
+        case .failedToEnumerateAAPTResources(let directory, let target):
+          return """
+            Failed to enumerate resources in directory at \
+            '\(directory.path)' for target '\(target.name)' in package with \
+            identity '\(target.package.identity)'
+            """
+        case .failedToCopyAAPTResource(let source, let destination):
+          return """
+            Failed to copy resource from '\(source.path)' to \
+            '\(destination.path)'
+            """
+        case .unsupportedAAPTResources(let target):
+          return """
+            Android resources are not supported in non-executable targets (found in \
+            '\(target.name)')
             """
         case .cannotBundleAPKWithoutSwiftAndroidSDK:
           return "Cannot bundle APK without Swift Android SDK"

--- a/Sources/SwiftBundler/Bundler/APKBundlerError.swift
+++ b/Sources/SwiftBundler/Bundler/APKBundlerError.swift
@@ -109,7 +109,7 @@ extension APKBundler {
         case .unsupportedAAPTResources(let target):
           return """
             Android resources are not supported in non-executable targets (found in \
-            '\(target.name)')
+            '\(target.name)', in package '\(target.package.identity)')
             """
         case .cannotBundleAPKWithoutSwiftAndroidSDK:
           return "Cannot bundle APK without Swift Android SDK"

--- a/Sources/SwiftBundler/Bundler/APKBundlerProjectStructure.swift
+++ b/Sources/SwiftBundler/Bundler/APKBundlerProjectStructure.swift
@@ -33,6 +33,8 @@ extension APKBundler {
     var androidManifest: URL
     /// The root directory of the Java source package struture.
     var javaSourceDirectory: URL
+    /// The root directory of the AAPT resources.
+    var resourceDirectory: URL
     /// The directory containing Java source files for the app's main package.
     var mainJavaPackageDirectory: URL
     /// The `MainActivity.java` source file.
@@ -102,6 +104,7 @@ extension APKBundler {
       let identifierPath = appIdentifier.lowercased()
         .replacingOccurrences(of: ".", with: "/")
       javaSourceDirectory = srcMain / "java"
+      resourceDirectory = srcMain / "res"
       mainJavaPackageDirectory = javaSourceDirectory / identifierPath
       mainActivitySource = mainJavaPackageDirectory / "\(mainActivityName).java"
       cmakeLists = srcMain / "CMakeLists.txt"

--- a/Sources/SwiftBundler/Configuration/TargetConfiguration.swift
+++ b/Sources/SwiftBundler/Configuration/TargetConfiguration.swift
@@ -29,5 +29,21 @@ struct TargetConfiguration: Codable, Hashable, Sendable {
     ///
     /// Defaults to the value of ``javaDirectory``.
     var kotlinDirectory: String?
+    /// The directory to find resource files in, such as XML resources.
+    ///
+    /// If not provided, resource linking is skipped.
+    var resourceDirectory: String?
+    /// Additional AAPT options.
+    var aapt: AAPTOptions?
+
+    // https://developer.android.com/reference/tools/gradle-api/8.1/com/android/build/api/dsl/AndroidResources
+    @Configuration(overlayable: false)
+    struct AAPTOptions: Codable, Sendable {
+      var ignoreAssetsPatterns: [String]?
+      var noCompress: [String]?
+      var failOnMissingConfigEntry: Bool?
+      var additionalParameters: [String]?
+      var namespaced: Bool?
+    }
   }
 }

--- a/Sources/SwiftBundler/Configuration/TargetConfiguration.swift
+++ b/Sources/SwiftBundler/Configuration/TargetConfiguration.swift
@@ -37,13 +37,31 @@ struct TargetConfiguration: Codable, Hashable, Sendable {
     var aapt: AAPTOptions?
 
     // https://developer.android.com/reference/tools/gradle-api/8.1/com/android/build/api/dsl/AndroidResources
-    @Configuration(overlayable: false)
-    struct AAPTOptions: Codable, Sendable {
+    @Mergeable
+    struct AAPTOptions: Codable, Hashable, Sendable, Flattenable {
       var ignoreAssetsPatterns: [String]?
       var noCompress: [String]?
       var failOnMissingConfigEntry: Bool?
       var additionalParameters: [String]?
       var namespaced: Bool?
+    
+      struct Flat: Hashable, Sendable {
+        var ignoreAssetsPatterns: [String]
+        var noCompress: [String]
+        var failOnMissingConfigEntry: Bool?
+        var additionalParameters: [String]
+        var namespaced: Bool?
+      }
+        
+      func flatten(with context: ConfigurationFlattener.Context) throws(ConfigurationFlattener.Error) -> Flat {
+        Flat(
+          ignoreAssetsPatterns: ignoreAssetsPatterns ?? [],
+          noCompress: noCompress ?? [],
+          failOnMissingConfigEntry: failOnMissingConfigEntry,
+          additionalParameters: additionalParameters ?? [],
+          namespaced: namespaced
+        )
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes #190

This PR adds preliminary AAPT resource support. It's currently only supported in executable targets, as library targets would not be able to access the generated classes. The configuration is present in two new keys on the existing Android options:
- `resource_directory` is a string naming a directory. The contents of that directory are copied into `res` in the project, the same way `java_directory` is copied into `java`.
- `aapt` is an object representing the `androidResources` (formerly `aaptOptions`) Gradle config block.

Example config excerpt:
```toml
[targets.MyTestApp.android]
kotlin_directory = "kotlin"
resource_directory = "res"
aapt.no_compress = ["flac"]
```