### PR TITLE
Improve dev experience of working with dependencies

### DIFF
--- a/Sources/SwiftBundler/Bundler/SwiftPackageManager/PackageGraph.swift
+++ b/Sources/SwiftBundler/Bundler/SwiftPackageManager/PackageGraph.swift
@@ -286,8 +286,8 @@ extension SwiftPackageManager {
         let nestedDirectDependencies = try directTargetDependencies(
           ofTarget: dependency.target.name,
           inPackage: dependency.target.package
-        ).map { dependency in
-          dependency.appendingConditions(dependency.conditions)
+        ).map { nestedDependency in
+          nestedDependency.appendingConditions(dependency.conditions)
         }
 
         for dependency in nestedDirectDependencies {

--- a/Sources/SwiftBundler/Commands/BundleArguments.swift
+++ b/Sources/SwiftBundler/Commands/BundleArguments.swift
@@ -282,4 +282,14 @@ struct BundleArguments: ParsableArguments {
     )
   #endif
   var noXcodebuild = false
+
+  /// Whether to skip building dependencies or not.
+  @Flag(
+    name: .long,
+    help: """
+      Skip building dependencies. Use with caution. Applies to project \
+      dependencies, not SwiftPM dependencies.
+      """
+  )
+  var skipDependencies = false
 }

--- a/Sources/SwiftBundler/Commands/BundleCommand.swift
+++ b/Sources/SwiftBundler/Commands/BundleCommand.swift
@@ -1025,7 +1025,7 @@ struct BundleCommand: ErrorHandledCommand {
           rootPackageScratchDirectory: buildContext.genericContext.scratchDirectory,
           swiftToolchain: context.toolchain,
           appName: context.appName,
-          dryRun: skipBuild
+          dryRun: skipBuild || arguments.skipDependencies
         )
       }
       bundlerContext.builtDependencies = dependencies


### PR DESCRIPTION
This PR improves the dev experience of working with dependencies, by allowing devs to opt to skip building dependencies when they know that the dependencies haven't changed.

I've also fixed a bug that was causing unnecessary work to be performed when building SwiftCrossUI apps for non-Windows platforms. There was previously a bug in the logic that collects the conditions required for a given target to end up in the final executable, leading Swift Bundler to believe that WinAppSDK was in use on platforms other than Windows (even though it's only used on Windows). It would then download the Windows App Runtime installer, even though it's not required outside of Windows.