### PR TITLE
Add cause to 'failed to count revisions' error message

### DIFF
--- a/Sources/SwiftBundler/Bundler/Git.swift
+++ b/Sources/SwiftBundler/Bundler/Git.swift
@@ -74,7 +74,7 @@ enum Git {
         directory: repository
       ).getOutput(excludeStdError: true).trimmingCharacters(in: .whitespacesAndNewlines)
     } catch {
-      throw Error(.failedToCountRevisions(repository, revision))
+      throw Error(.failedToCountRevisions(repository, revision), cause: error)
     }
 
     guard let count = Int(digits) else {


### PR DESCRIPTION
Swift Bundler wasn't attaching the underlying error, making the error less useful than it could be.