### PR TITLE
Various MSI bundling improvements

### DIFF
--- a/Sources/SwiftBundler/Bundler/BundlerContext.swift
+++ b/Sources/SwiftBundler/Bundler/BundlerContext.swift
@@ -22,6 +22,9 @@ struct BundlerContext {
   /// The architectures that the app has been built for.
   var architectures: [BuildArchitecture]
 
+  /// The configuration that the app was built with.
+  var buildConfiguration: BuildConfiguration
+
   /// The target platform.
   var platform: Platform
   /// The target platform version (e.g. iOS version or Android API version).

--- a/Sources/SwiftBundler/Bundler/MSIBundler.swift
+++ b/Sources/SwiftBundler/Bundler/MSIBundler.swift
@@ -61,21 +61,25 @@ enum MSIBundler: Bundler {
       try contents.write(to: wxsFile)
     }
 
-    log.info("Running WiX MSI builder")
-    let process = Process.create(
-      "wix",
-      arguments: [
-        "build",
-        "-b", genericBundlerOutput.root.path,
-        "-o", outputStructure.bundle.path,
-        "-arch", "x64",
-        wxsFile.path,
-      ],
-      runSilentlyWhenNotVerbose: false
-    )
+    let wixExtensions = context.appConfiguration.msi?.wixExtensions ?? []
+    try await Error.catch {
+      try await WiXTool.ensureExtensions(
+        wixExtensions,
+        workspaceRoot: context.packageDirectory
+      )
+    }
 
-    try await Error.catch(withMessage: .failedToRunWiX) {
-      try await process.runAndWait()
+    log.info("Running WiX MSI builder")
+    let architecture = context.architectures[0]
+    try await Error.catch {
+      try await WiXTool.build(
+        wxsFile: wxsFile,
+        sourceDirectory: genericBundlerOutput.root,
+        outputLocation: outputStructure.bundle,
+        architecture: architecture,
+        workspaceRoot: context.packageDirectory,
+        extensions: wixExtensions.map(\.identifier)
+      )
     }
 
     if let codeSigningContext = context.windowsCodeSigningContext {

--- a/Sources/SwiftBundler/Bundler/MSIBundler.swift
+++ b/Sources/SwiftBundler/Bundler/MSIBundler.swift
@@ -138,9 +138,23 @@ enum MSIBundler: Bundler {
       withSeed: appConfiguration.identifier
     ).description
 
+    let excludedPaths = [genericBundle.mainExecutable.path]
     let installFolder = try enumerate(
       genericBundle.root,
-      excluding: [genericBundle.mainExecutable],
+      inclusionPredicate:  { item in
+        // For some reason URL comparison seems to be a little broken on Windows.
+        // URLs with identical paths get evaluated as distinct URLs, so we have to
+        // convert to paths before comparison.
+        if excludedPaths.contains(item.path) {
+          return false
+        } else if context.buildConfiguration == .release {
+          // In release builds we skip pdb files (Windows debug information)
+          return item.pathExtension != "pdb"
+        } else {
+          // In debug mode we include everything that's not explicitly excluded
+          return true
+        }
+      },
       id: "InstallFolder"
     )
 
@@ -277,20 +291,14 @@ enum MSIBundler: Bundler {
   private static func enumerate(
     _ directory: URL,
     withRespectTo root: URL? = nil,
-    excluding excludedItems: [URL] = [],
+    inclusionPredicate: (URL) -> Bool,
     id: String? = nil
   ) throws(Error) -> WXSFile.Directory {
     let root = root ?? directory
-    let excludedPaths = excludedItems.map(\.path)
 
     let items: [URL] = try Error.catch(withMessage: .failedToEnumerateBundle) {
       try FileManager.default.contentsOfDirectory(at: directory)
-    }.filter { item in
-      // For some reason URL comparison seems to be a little broken on Windows.
-      // URLs with identical paths get evaluated as distinct URLs, so we have to
-      // convert to paths before comparison.
-      return !excludedPaths.contains(item.path)
-    }
+    }.filter(inclusionPredicate)
 
     let files = items.filter { item in
       item.exists(withType: .file)
@@ -302,7 +310,11 @@ enum MSIBundler: Bundler {
     let directories = try items.filter { item in
       item.exists(withType: .directory)
     }.map { (subdirectory) throws(Error) -> WXSFile.Directory in
-      try enumerate(subdirectory, withRespectTo: root, excluding: excludedItems)
+      try enumerate(
+        subdirectory,
+        withRespectTo: root,
+        inclusionPredicate: inclusionPredicate
+      )
     }
 
     // Enumerate each directory and then combine files and directories into

--- a/Sources/SwiftBundler/Bundler/NuGetTool.swift
+++ b/Sources/SwiftBundler/Bundler/NuGetTool.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Version
+
+/// A utility that wraps the NuGet CLI (and manages downloading/installing it).
+enum NuGetTool {
+  /// The URL that we download the NuGet CLI from. They only provide x86 builds,
+  /// so we install the same executable no matter the host architecture and rely
+  /// on Windows' built-in emulation.
+  static let nugetDownloadURL = URL(
+    string: "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
+  )!
+
+  /// Ensures that Swift Bundler's copy of the NuGet CLI is available. Attempts
+  /// to download the CLI if it's not available.
+  /// - Returns: The location of Swift Bundler's NuGet CLI on disk.
+  static func ensureNuGetCLI() throws(Error) -> URL {
+    let toolsDirectory = try Error.catch {
+      try System.getToolsDirectory()
+    }
+
+    let nuget = toolsDirectory / "nuget.exe"
+    if nuget.exists() {
+      return nuget
+    }
+
+    log.info("Downloading NuGet")
+    log.debug("Downloading NuGet from \(nugetDownloadURL.absoluteString)")
+    try Error.catch(withMessage: .failedToDownloadNuGetCLI) {
+      let content = try Data(contentsOf: nugetDownloadURL)
+      try content.write(to: nuget)
+    }
+
+    return nuget
+  }
+
+  /// Installs a package in the given directory.
+  static func installPackage(
+    _ packageName: String,
+    version: Version? = nil,
+    in directory: URL
+  ) async throws(Error) {
+    var arguments = ["install", packageName]
+    if let version {
+      arguments += ["-Version", version.description]
+    }
+
+    try await Error.catch(withMessage: .failedToInstallPackage(packageName, version)) {
+      try await Process.create(
+        try ensureNuGetCLI().path,
+        arguments: arguments,
+        directory: directory
+      ).runAndWait()
+    }
+  }
+}

--- a/Sources/SwiftBundler/Bundler/NuGetToolError.swift
+++ b/Sources/SwiftBundler/Bundler/NuGetToolError.swift
@@ -1,0 +1,25 @@
+import ErrorKit
+import Version
+
+extension NuGetTool {
+  typealias Error = RichError<ErrorMessage>
+
+  /// An error message related to ``NuGetTool``.
+  enum ErrorMessage: Throwable {
+    case failedToDownloadNuGetCLI
+    case failedToInstallPackage(String, Version?)
+
+    var userFriendlyMessage: String {
+      switch self {
+        case .failedToDownloadNuGetCLI:
+          return "Failed to download the NuGet CLI"
+        case .failedToInstallPackage(let name, let version):
+          if let version {
+            return "Failed to install \(name) @ \(version)"
+          } else {
+            return "Failed to install \(name)"
+          }
+      }
+    }
+  }
+}

--- a/Sources/SwiftBundler/Bundler/SwiftPackageManager/BuildArchitecture.swift
+++ b/Sources/SwiftBundler/Bundler/SwiftPackageManager/BuildArchitecture.swift
@@ -66,6 +66,19 @@ enum BuildArchitecture: String, CaseIterable, ExpressibleByArgument {
         "amd64"
     }
   }
+
+  /// The name to use for this architecture when invoking the WiX CLI.
+  var wixName: String {
+    switch self {
+      case .arm64, .x86:
+        rawValue
+      case .x86_64:
+        "x64"
+      case .armv7:
+        // This one isn't supported by WiX
+        "armv7"
+    }
+  }
 }
 
 extension BuildArchitecture {

--- a/Sources/SwiftBundler/Bundler/WiXTool.swift
+++ b/Sources/SwiftBundler/Bundler/WiXTool.swift
@@ -1,0 +1,247 @@
+import Foundation
+import Version
+
+/// A utility that wraps the WiX CLI (used to create Windows MSIs).
+enum WiXTool {
+  /// The base WiX download URL. Append a semantic version to get the actual download URL.
+  static let wixBaseDownloadURL = URL(
+    string: "https://www.nuget.org/api/v2/package/wix"
+  )!
+
+  /// The WiX CLI version that Swift Bundler uses.
+  static let wixCLIVersion = Version(6, 0, 0)
+
+  /// Builds the WiX package described by the given WXS file.
+  /// - Parameter workspaceRoot: The directory that extensions are installed in.
+  ///   Should generally be whatever the user perceives as their current project's
+  ///   root directory so that they can easily run failing wix commands themselves
+  ///   to debug issues.
+  static func build(
+    wxsFile: URL,
+    sourceDirectory: URL,
+    outputLocation: URL,
+    architecture: BuildArchitecture,
+    workspaceRoot: URL,
+    extensions: [String]
+  ) async throws(Error) {
+    let wixCLI = try await Error.catch {
+      try await WiXTool.ensureWiXCLI(version: wixCLIVersion)
+    }
+
+    try await Error.catch {
+      try await Process.create(
+        wixCLI.path,
+        arguments: [
+          "build",
+          "-b", sourceDirectory.path,
+          "-o", outputLocation.path,
+          "-arch", architecture.wixName,
+          wxsFile.path,
+        ] + extensions.flatMap { ["-ext", $0] },
+        runSilentlyWhenNotVerbose: false
+      ).runAndWait()
+    }
+  }
+
+  /// A WiX extension specifier. Encoded as '<identifier>/<specifier>'
+  /// (e.g. 'WixToolset.Util.wixext/6.0.0').
+  struct ExtensionSpecifier: CustomStringConvertible, Hashable, Sendable,
+    Codable, TriviallyFlattenable
+  {
+    var identifier: String
+    var version: Version
+
+    var description: String {
+      "\(identifier)/\(version)"
+    }
+
+    init(parsing specifier: String) throws(Error) {
+      let parts = specifier.split(
+        separator: "/",
+        maxSplits: 1,
+        omittingEmptySubsequences: false
+      )
+
+      guard parts.count == 2 else {
+        throw Error(.invalidExtensionSpecifier(specifier))
+      }
+
+      identifier = String(parts[0])
+      let versionString = String(parts[1])
+      guard let version = Version(tolerant: versionString) else {
+        throw Error(.invalidExtensionVersion(identifier, versionString))
+      }
+      self.version = version
+    }
+
+    init(from decoder: any Decoder) throws {
+      let container = try decoder.singleValueContainer()
+      let value = try container.decode(String.self)
+      try self.init(parsing: value)
+    }
+
+    func encode(to encoder: any Encoder) throws {
+      var container = encoder.singleValueContainer()
+      try container.encode(description)
+    }
+  }
+
+  /// Ensures that a requested set of WiX extensions is available in the current
+  /// workspace.
+  static func ensureExtensions(
+    _ extensions: [ExtensionSpecifier],
+    workspaceRoot: URL
+  ) async throws(Error) {
+    guard !extensions.isEmpty else {
+      return
+    }
+
+    let installedExtensions = try await listExtensions(workspaceRoot: workspaceRoot)
+    for requestedExtension in extensions {
+      guard !installedExtensions.contains(requestedExtension) else { continue }
+      log.info("Installing WiX extension \(requestedExtension)")
+      try await installExtension(requestedExtension, workspaceRoot: workspaceRoot)
+    }
+  }
+
+  /// Lists available extensions in the current workspace.
+  static func listExtensions(
+    workspaceRoot: URL
+  ) async throws(Error) -> [ExtensionSpecifier] {
+    let wixCLI = try await Error.catch {
+      try await WiXTool.ensureWiXCLI(version: wixCLIVersion)
+    }
+
+    let output = try await Error.catch {
+      do {
+        return try await Process.create(
+          wixCLI.path,
+          arguments: [
+            "extension",
+            "list"
+          ],
+          directory: workspaceRoot
+        ).getOutput()
+      } catch let error as Process.Error {
+        // 'wix extension list' exits with the status code '2' when there aren't
+        // any extensions to list.
+        switch error.message {
+          case .nonZeroExitStatusWithOutput(let output, _, 2):
+            if output.isEmpty {
+              return ""
+            } else {
+              throw error
+            }
+          default:
+            throw error
+        }
+      }
+    }.trimmingCharacters(in: .whitespacesAndNewlines)
+
+    let lines = output.split(separator: "\n").map { line in
+      String(line.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    return try lines.map { line throws(Error) in
+      try ExtensionSpecifier(parsing: line)
+    }
+  }
+
+  /// Installs the given WiX extension.
+  /// - Parameter workspaceRoot: The directory that extensions are installed in.
+  ///   Should generally be whatever the user perceives as their current project's
+  ///   root directory so that they can easily run failing wix commands themselves
+  ///   to debug issues.
+  static func installExtension(
+    _ specifier: ExtensionSpecifier,
+    workspaceRoot: URL
+  ) async throws(Error) {
+    let wixCLI = try await Error.catch {
+      try await WiXTool.ensureWiXCLI(version: wixCLIVersion)
+    }
+
+    try await Error.catch {
+      try await Process.create(
+        wixCLI.path,
+        arguments: [
+          "extension",
+          "add",
+          specifier.description
+        ],
+        directory: workspaceRoot
+      ).runAndWait()
+    }
+  }
+
+  /// Ensures that Swift Bundler has specified version of the WiX CLI available.
+  /// Attempts to download the CLI if it's not available.
+  /// - Returns: The location of Swift Bundler's WiX CLI (with the specified version)
+  ///   on disk.
+  static func ensureWiXCLI(version: Version) async throws(Error) -> URL {
+    let toolsDirectory = try Error.catch {
+      try System.getToolsDirectory()
+    }
+
+    let wixInstallDirectory = toolsDirectory / "wix-\(version)"
+    let wix = wixInstallDirectory / "wix.exe"
+    if wix.exists() {
+      return wix
+    }
+
+    let wixDownloadURL = wixBaseDownloadURL / version.description
+    log.info("Downloading WiX")
+    log.debug("Downloading WiX from \(wixDownloadURL.absoluteString)")
+    let uuid = UUID().uuidString
+    let temp = FileManager.default.temporaryDirectory
+    let wixZip = temp / "wix-\(uuid).zip"
+    let wixDirectory = temp / "wix-\(uuid)"
+    try Error.catch(withMessage: .failedToDownloadWiXCLI) {
+      let content = try Data(contentsOf: wixDownloadURL)
+      try content.write(to: wixZip)
+      try FileManager.default.unzipItem(at: wixZip, to: wixDirectory)
+    }
+
+    defer {
+      try? FileManager.default.removeItem(at: wixZip)
+    }
+
+    // Locate the subdirectory containing the tool itself
+    let subdirectory = try Error.catch {
+      let packageToolsDirectory = wixDirectory / "tools"
+      let contents = try FileManager.default.contentsOfDirectory(at: packageToolsDirectory)
+        .map(\.lastPathComponent)
+      if contents.contains("net8.0") {
+        return packageToolsDirectory / "net8.0"
+      } else {
+        // Stably guess a subdirectory. If net8.0 doesn't exist, we hope to find
+        // a newer version of the net subdirectory.
+        let contents = contents.sorted()
+        if let directory = contents.first(where: { $0.hasPrefix("net") }) {
+          return packageToolsDirectory / directory
+        } else if let directory = contents.first {
+          return packageToolsDirectory / directory
+        }
+      }
+
+      throw Error(.failedToLocateWiXCLI(directory: wixDirectory, guess: nil))
+    } / "any"
+
+    let guess = subdirectory / "wix.exe"
+    guard guess.exists() else {
+      throw Error(.failedToLocateWiXCLI(directory: wixDirectory, guess: guess))
+    }
+
+    try Error.catch {
+      try FileManager.default.copyItem(
+        at: subdirectory,
+        to: wixInstallDirectory
+      )
+    }
+    
+    // Only remove the directory if we successfully locate the executable, to make
+    // debugging a little easier
+    try? FileManager.default.removeItem(at: wixDirectory)
+
+    return wix
+  }
+}

--- a/Sources/SwiftBundler/Bundler/WiXToolError.swift
+++ b/Sources/SwiftBundler/Bundler/WiXToolError.swift
@@ -1,0 +1,37 @@
+import ErrorKit
+import Foundation
+
+extension WiXTool {
+  typealias Error = RichError<ErrorMessage>
+
+  /// An error message related to ``WiXTool``.
+  enum ErrorMessage: Throwable {
+    case failedToDownloadWiXCLI
+    case failedToLocateWiXCLI(directory: URL, guess: URL?)
+    case invalidExtensionSpecifier(String)
+    case invalidExtensionVersion(_ identifier: String, _ version: String)
+
+    var userFriendlyMessage: String {
+      switch self {
+        case .failedToDownloadWiXCLI:
+          return "Failed to download the WiX CLI"
+        case .failedToLocateWiXCLI(let directory, let guess):
+          var message = """
+            Failed to locate wix CLI in unzipped package located at \
+            \(directory.path)
+            """
+          if let guess {
+            message += "; expected to find the CLI at \(guess.path)"
+          }
+          return message
+        case .invalidExtensionSpecifier(let specifier):
+          return """
+            Got invalid WiX extension specifier '\(specifier)'; expected \
+            '<identifier>/<version>' (e.g. 'WixToolset.Util.wixext/6.0.0')
+            """
+        case .invalidExtensionVersion(let identifier, let version):
+          return "Got invalid version '\(version)' for WiX extension '\(identifier)'"
+      }
+    }
+  }
+}

--- a/Sources/SwiftBundler/Commands/BundleCommand.swift
+++ b/Sources/SwiftBundler/Commands/BundleCommand.swift
@@ -974,6 +974,7 @@ struct BundleCommand: ErrorHandledCommand {
         outputDirectory: appOutputDirectory,
         packageGraph: SwiftPackageManager.PackageGraph.dummy,
         architectures: buildContext.genericContext.architectures,
+        buildConfiguration: buildContext.genericContext.configuration,
         platform: context.platform,
         platformVersion: context.platformVersion,
         device: context.device,

--- a/Sources/SwiftBundler/Configuration/MSIBundlerConfiguration.swift
+++ b/Sources/SwiftBundler/Configuration/MSIBundlerConfiguration.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XMLCoder
+import Version
 
 /// MSI bundler related configuration properties.
 @Configuration(overlayable: false)
@@ -34,4 +35,7 @@ struct MSIBundlerConfiguration: Codable, Sendable {
   /// ]
   /// ```
   var wxsExtras: [WXSValue]?
+
+  /// WiX extensions required to build an MSI installer of the app.
+  var wixExtensions: [WiXTool.ExtensionSpecifier]?
 }

--- a/Sources/SwiftBundler/Configuration/WXSValue.swift
+++ b/Sources/SwiftBundler/Configuration/WXSValue.swift
@@ -2,6 +2,7 @@ struct WXSValue: TriviallyFlattenable, Sendable {
   var tag: String
   var attributes: [String: String]
   var children: [WXSValue]
+  var content: String?
 }
 
 extension WXSValue: Codable {
@@ -12,9 +13,10 @@ extension WXSValue: Codable {
 
     static let tag = Self("tag")
     static let children = Self("children")
+    static let content = Self("content")
 
     var isSpecial: Bool {
-      self == .tag || self == .children
+      self == .tag || self == .children || self == .content
     }
 
     init?(intValue: Int) {
@@ -37,6 +39,10 @@ extension WXSValue: Codable {
       self.children = []
     }
 
+    if container.contains(.content) {
+      content = try container.decode(String.self, forKey: .content)
+    }
+
     var keys = container.allKeys
     keys = keys.filter { !$0.isSpecial }
     attributes = [:]
@@ -50,6 +56,7 @@ extension WXSValue: Codable {
     var container = encoder.container(keyedBy: Key.self)
     try container.encode(tag, forKey: .tag)
     try container.encode(children, forKey: .children)
+    try container.encode(content, forKey: .content)
     for (key, value) in attributes {
       try container.encode(value, forKey: Key(key))
     }

--- a/Sources/SwiftBundler/Configuration/WXSValueXML.swift
+++ b/Sources/SwiftBundler/Configuration/WXSValueXML.swift
@@ -9,13 +9,6 @@ struct WXSValueXML: Encodable {
 
     var intValue: Int? { nil}
 
-    static let tag = Self("tag")
-    static let children = Self("children")
-
-    var isSpecial: Bool {
-      self == .tag || self == .children
-    }
-
     init?(intValue: Int) {
       return nil
     }
@@ -44,6 +37,10 @@ struct WXSValueXML: Encodable {
 
     for (tag, group) in groupedChildren {
       try container.encode(Element(group), forKey: Key(tag))
+    }
+
+    if let content = value.content {
+      try container.encode(content, forKey: Key(""))
     }
   }
 }


### PR DESCRIPTION
First, this PR enables developers to specify the content of XML tags when customising their app's WXS manifest from Bundler.toml (in addition to being able to configure attributes and child elements, which was already possible);

```toml
msi.wxs_extras = [
  {
    tag = "ATagThatRequiresSettingXMLContent",
    content = "Raw text content that goes between the tags",
    children = [{ tag = "AChildTag" }],
    AnAttribute = "A value",
  }
]
```

This PR also updates Swift Bundler's MSIBundler to automatically install a compatible version of the WiX CLI on the user's behalf (local to Swift Bundler to avoid interfering with other tools on the system or existing wix installations).

In addition to that, apps can now specify WiX extensions that they would like to use. WiX extensions are particularly useful when you need to create custom install steps that run commands in the background or launch your application after the install completes.

```toml
msi.wix_extensions = ["WixToolset.Util.wixext/6.0.0"]
```

And finally, this PR updates the MSI bundling logic to exclude PDB files when bundling release builds of apps, which helps reduce install size quite significantly in some cases.