### PR TITLE
Update sponsorship information to point to the moreSwift Open Collective

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
+open_collective: moreSwift
 github: stackotter

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ## Supporting Swift Bundler ❤️
 
-If you find Swift Bundler useful, please consider supporting me by [becoming a sponsor](https://github.com/sponsors/stackotter). I spend most of my spare time working on open-source projects, and each sponsorship helps me focus more time on making high quality tools for the community.
+If you find Swift Bundler useful, please consider supporting its development by [becoming a sponsor](https://opencollective.com/moreswift). moreSwift's core contributors spend much of their spare time working on open-source projects, and each sponsorship helps us to focus more time on making high quality tools for the community.
 
 ## Documentation 📚
 


### PR DESCRIPTION
moreSwift now has an [Open Collective](https://opencollective.com/moreswift)! This PR updates the README.md and FUNDING.yml files to point to this new sponsorship portal.