### PR TITLE
Remove stackotter from FUNDING.yml (GitHub displays it too prominently)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,1 @@
 open_collective: moreSwift
-github: stackotter


### PR DESCRIPTION
I'm removing myself from the `FUNDING.yml` because GitHub was displaying my personal GitHub sponsors page more prominently than the moreSwift Open Collective page. The Open Collective is now our primary avenue for collecting sponsorship, so it should be the most prominent option.