### PR TITLE
Implement required_config_version field for conditional overlays

### DIFF
--- a/.github/workflows/swift-windows.yml
+++ b/.github/workflows/swift-windows.yml
@@ -15,7 +15,7 @@ defaults:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2022
     timeout-minutes: 30
     steps:
       - name: Setup VS Dev Environment

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a5d781507088a0ab0eae81f6d27c4e630e057e532441317066c8fd257bd115fd",
+  "originHash" : "8f6c0b60e995f8fb408d3e3596f159f01af1066634561455fadd05faeba36064",
   "pins" : [
     {
       "identity" : "aexml",
@@ -321,8 +321,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stackotter/TOMLKit",
       "state" : {
-        "revision" : "fc32cb1b94aa2f8721c1585341ef723a0b4a6ab8",
-        "version" : "0.7.0"
+        "revision" : "6206c73fc5adb16b0f75665a1c5fcf1f7da4be1b",
+        "version" : "0.7.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,7 @@ let package = Package(
     // This fork removes the dependency on swift-syntax (which was used for
     // features we don't use) to speed up Swift Bundler release builds
     .package(url: "https://github.com/stackotter/swift-parsing", .upToNextMinor(from: "0.15.0")),
-    .package(url: "https://github.com/stackotter/TOMLKit", from: "0.7.0"),
+    .package(url: "https://github.com/stackotter/TOMLKit", from: "0.7.1"),
     .package(url: "https://github.com/onevcat/Rainbow", from: "4.0.0"),
     .package(url: "https://github.com/mxcl/Version", from: "2.0.0"),
     .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.0.0"),

--- a/Sources/SwiftBundler/Configuration/ConfigurationFlattener.swift
+++ b/Sources/SwiftBundler/Configuration/ConfigurationFlattener.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Version
 
 /// Evaluates a configuration's overlays and performs any other useful
 /// transformations or validations at the same time.
@@ -138,6 +137,8 @@ enum ConfigurationFlattener {
       case .arch(let identifier):
         // TODO(stackotter): Do people find this condition interpretation intuitive?
         context.architectures.map(\.rawValue).contains(identifier)
+      case .false:
+        false
     }
   }
 }

--- a/Sources/SwiftBundler/Configuration/ConfigurationOverlay.swift
+++ b/Sources/SwiftBundler/Configuration/ConfigurationOverlay.swift
@@ -7,7 +7,16 @@ protocol ConfigurationOverlay {
 
   static var exclusiveProperties: [OverlayCondition: PropertySet<Self>] { get }
 
+  /// The condition that controls when this overlay is active.
   var condition: OverlayCondition { get }
+  /// The Swift Bundler version required to parse this overlay. If the current
+  /// Swift Bundler version is too old to parse the overlay, then the overlay's
+  /// contents get stored in ``lazyContent`` and the ``condition`` gets set to
+  /// ``OverlayCondition/false``.
+  var requiredConfigVersion: Version? { get }
+  /// Overlay content that was lazily loaded, generally due to
+  /// ``requiredConfigVersion`` being higher than ``SwiftBundler/version``.
+  var lazyContent: [String: TOMLValue] { get }
 
   func merge(into base: inout Base)
 }
@@ -123,6 +132,7 @@ enum OverlayCondition: Codable, Hashable, CustomStringConvertible {
   case platform(String)
   case bundler(String)
   case arch(String)
+  case `false`
 
   var description: String {
     switch self {
@@ -132,6 +142,8 @@ enum OverlayCondition: Codable, Hashable, CustomStringConvertible {
         return "bundler(\(identifier))"
       case .arch(let arch):
         return "arch(\(arch))"
+      case .false:
+        return "false"
     }
   }
 
@@ -185,6 +197,10 @@ enum OverlayCondition: Codable, Hashable, CustomStringConvertible {
       }.map { arch in
         OverlayCondition.arch(arch.rawValue)
       }
+
+      Parse {
+        "false"
+      }.map { OverlayCondition.false }
     }
 
     self = try parser.parse(value)
@@ -192,17 +208,6 @@ enum OverlayCondition: Codable, Hashable, CustomStringConvertible {
 
   func encode(to encoder: any Encoder) throws {
     var container = encoder.singleValueContainer()
-
-    let value: String
-    switch self {
-      case .platform(let identifier):
-        value = "platform(\(identifier))"
-      case .bundler(let identifier):
-        value = "bundler(\(identifier))"
-      case .arch(let identifier):
-        value = "arch(\(identifier))"
-    }
-
-    try container.encode(value)
+    try container.encode(description)
   }
 }

--- a/Sources/SwiftBundler/Configuration/PackageConfiguration.swift
+++ b/Sources/SwiftBundler/Configuration/PackageConfiguration.swift
@@ -139,10 +139,10 @@ struct PackageConfiguration: Codable, Hashable, Sendable {
 
       // For a month or so, the format_version was bumped to version 3. We now
       // consider both format versions to be equivalent even though format version
-      // 3 contained some additive, because treating them as separate (and generating
-      // new Bundler.toml files with a format_version of 3), causes pre-release
-      // Swift Bundler 3.0.0 builds to spit out cryptic errors (due to Swift Bundler
-      // previously not checking the format_version field properly...)
+      // 3 contained some additive changes, because treating them as separate (and
+      // generating new Bundler.toml files with a format_version of 3), causes
+      // pre-release Swift Bundler 3.0.0 builds to spit out cryptic errors (due to
+      // Swift Bundler previously not checking the format_version field properly...)
       guard formatVersionInt == 2 || formatVersionInt == 3 else {
         throw Error(.unsupportedFormatVersion(formatVersionInt))
       }
@@ -190,6 +190,7 @@ struct PackageConfiguration: Codable, Hashable, Sendable {
         var decoder = TOMLDecoder(strictDecoding: true)
         // Tolerant version parsing
         decoder.userInfo[.decodingMethod] = DecodingMethod.tolerant
+        decoder.userInfo[.swiftBundlerVersion] = SwiftBundler.version
         return try decoder.decode(
           PackageConfiguration.self,
           from: table
@@ -355,4 +356,9 @@ extension PackageConfiguration.Flat {
       throw PackageConfiguration.Error(.noApps)
     }
   }
+}
+
+extension CodingUserInfoKey {
+  /// The Swift Bundler version that is parsing the configuration.
+  static let swiftBundlerVersion = Self(rawValue: "swiftBundlerVersion")!
 }

--- a/Sources/SwiftBundler/Configuration/PackageConfiguration.swift
+++ b/Sources/SwiftBundler/Configuration/PackageConfiguration.swift
@@ -174,6 +174,10 @@ struct PackageConfiguration: Codable, Hashable, Sendable {
       configVersion = nil
     }
 
+    guard formatVersion == nil || configVersion == nil else {
+      throw Error(.formatVersionAndConfigVersionMutuallyExclusive)
+    }
+
     // If we're missing the format_version or config_version fields then we
     // assume we're working with a Swift Bundler 2.x configuration (not to
     // be confused with a 'format_version = 2' configuration...)
@@ -185,12 +189,19 @@ struct PackageConfiguration: Codable, Hashable, Sendable {
         mode: migrateConfiguration ? .writeChanges(backup: true) : .readOnly
       )
     } else {
+      let effectiveConfigVersion: Version
+      if let configVersion {
+        effectiveConfigVersion = configVersion
+      } else {
+        effectiveConfigVersion = Version(3, 0, 0)
+      }
+
       // Parse the config file as a post-v2 configuration
       configuration = try Error.catch(withMessage: .failedToDeserializeConfiguration) {
         var decoder = TOMLDecoder(strictDecoding: true)
         // Tolerant version parsing
         decoder.userInfo[.decodingMethod] = DecodingMethod.tolerant
-        decoder.userInfo[.swiftBundlerVersion] = SwiftBundler.version
+        decoder.userInfo[.swiftBundlerConfigVersion] = effectiveConfigVersion
         return try decoder.decode(
           PackageConfiguration.self,
           from: table
@@ -210,7 +221,7 @@ struct PackageConfiguration: Codable, Hashable, Sendable {
     }
   }
 
-  /// Migrates a Swift Bundler `v2.0.0` configuration file to the current configuration format.
+  /// Migrates a Swift Bundler `v2.x.x` configuration file to the current configuration format.
   ///
   /// Mutates the contents of the given configuration file.
   /// - Parameters:
@@ -359,6 +370,6 @@ extension PackageConfiguration.Flat {
 }
 
 extension CodingUserInfoKey {
-  /// The Swift Bundler version that is parsing the configuration.
-  static let swiftBundlerVersion = Self(rawValue: "swiftBundlerVersion")!
+  /// The Swift Bundler version to parse the config as.
+  static let swiftBundlerConfigVersion = Self(rawValue: "swiftBundlerConfigVersion")!
 }

--- a/Sources/SwiftBundler/Configuration/PackageConfigurationError.swift
+++ b/Sources/SwiftBundler/Configuration/PackageConfigurationError.swift
@@ -27,6 +27,7 @@ extension PackageConfiguration {
     case configVersionTooLow(Version)
     case unsupportedConfigVersion(Version)
     case requiredConfigVersionNotSupportedInOverlays
+    case formatVersionAndConfigVersionMutuallyExclusive
 
     var userFriendlyMessage: String {
       switch self {
@@ -96,9 +97,17 @@ extension PackageConfiguration {
             """
         case .requiredConfigVersionNotSupportedInOverlays:
           return """
-            The required_config_version overlay field is not supported in \
-            Swift Bundler \(SwiftBundler.version) or config files that use the \
-            pre-3.1.0 format_version field; it will be enabled in 3.1.0
+            The required_config_version overlay field is not available in config files \
+            that support Swift Bundler 3.0.0; it is available from 3.1.0 onwards; replace \
+            the format_version field with a config_version of at least 3.1.0 in order to \
+            use the required_config_version overlay field
+            """
+        case .formatVersionAndConfigVersionMutuallyExclusive:
+          return """
+            The format_version and config_version fields are mutually exclusive; \
+            config files should only use one or the other, not both; config_version \
+            is the newer of the two fields, and will become the default in Swift \
+            Bundler 4.0.0
             """
       }
     }

--- a/Sources/SwiftBundler/Configuration/PackageConfigurationError.swift
+++ b/Sources/SwiftBundler/Configuration/PackageConfigurationError.swift
@@ -26,8 +26,13 @@ extension PackageConfiguration {
     case invalidConfigVersion(any TOMLValueConvertible & Sendable)
     case configVersionTooLow(Version)
     case unsupportedConfigVersion(Version)
-    case requiredConfigVersionNotSupportedInOverlays
+    case requiredConfigVersionFieldNotSupportedByConfigVersion
     case formatVersionAndConfigVersionMutuallyExclusive
+    case requiredConfigVersionNotHigherThanConfigVersion(
+      _ required: Version,
+      _ configVersion: Version,
+      CodingPath
+    )
 
     var userFriendlyMessage: String {
       switch self {
@@ -38,7 +43,7 @@ extension PackageConfiguration {
         case .multipleAppsAndNoneSpecified:
           return "This package contains multiple apps. You must provide the 'app-name' argument"
         case .failedToEvaluateVariables:
-          return "Failed to evaluate all expressions"
+          return "Failed to evaluate all expressions" 
         case .failedToReadConfigurationFile(let file):
           return
             "Failed to read the configuration file at '\(file.relativePath)'. Are you sure that it exists?"
@@ -95,7 +100,7 @@ extension PackageConfiguration {
             The target project states a config_version of \(configVersion); you must \
             update to at least Swift Bundler \(configVersion) to work with this project
             """
-        case .requiredConfigVersionNotSupportedInOverlays:
+        case .requiredConfigVersionFieldNotSupportedByConfigVersion:
           return """
             The required_config_version overlay field is not available in config files \
             that support Swift Bundler 3.0.0; it is available from 3.1.0 onwards; replace \
@@ -108,6 +113,15 @@ extension PackageConfiguration {
             config files should only use one or the other, not both; config_version \
             is the newer of the two fields, and will become the default in Swift \
             Bundler 4.0.0
+            """
+        case .requiredConfigVersionNotHigherThanConfigVersion(
+          let requiredVersion,
+          let configVersion,
+          let codingPath
+        ):
+          return """
+            The required_config_version of \(requiredVersion) at \(codingPath) is \
+            redundant because config_version is \(configVersion)
             """
       }
     }

--- a/Sources/SwiftBundler/Configuration/PackageConfigurationError.swift
+++ b/Sources/SwiftBundler/Configuration/PackageConfigurationError.swift
@@ -26,6 +26,7 @@ extension PackageConfiguration {
     case invalidConfigVersion(any TOMLValueConvertible & Sendable)
     case configVersionTooLow(Version)
     case unsupportedConfigVersion(Version)
+    case requiredConfigVersionNotSupportedInOverlays
 
     var userFriendlyMessage: String {
       switch self {
@@ -92,6 +93,12 @@ extension PackageConfiguration {
           return """
             The target project states a config_version of \(configVersion); you must \
             update to at least Swift Bundler \(configVersion) to work with this project
+            """
+        case .requiredConfigVersionNotSupportedInOverlays:
+          return """
+            The required_config_version overlay field is not supported in \
+            Swift Bundler \(SwiftBundler.version) or config files that use the \
+            pre-3.1.0 format_version field; it will be enabled in 3.1.0
             """
       }
     }

--- a/Sources/SwiftBundler/Configuration/TOMLValue.swift
+++ b/Sources/SwiftBundler/Configuration/TOMLValue.swift
@@ -1,0 +1,65 @@
+import TOMLKit
+
+/// A decoded TOML value. Used to consume keys that Swift Bundler is
+/// intentionally skipping, or to store unhandled configuration that must
+/// be parsed or re-encoded at a later point in time.
+indirect enum TOMLValue: Codable, Hashable, Sendable {
+  case dateTime(TOMLDateTime)
+  case date(TOMLDate)
+  case time(TOMLTime)
+  case array([TOMLValue])
+  case table([String: TOMLValue])
+  case string(String)
+  case integer(Int)
+  case double(Double)
+  case boolean(Bool)
+
+  init(from decoder: any Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    if let dateTime = try? container.decode(TOMLDateTime.self) {
+      self = .dateTime(dateTime)
+    } else if let date = try? container.decode(TOMLDate.self) {
+      self = .date(date)
+    } else if let time = try? container.decode(TOMLTime.self) {
+      self = .time(time)
+    } else if let array = try? container.decode([TOMLValue].self) {
+      self = .array(array)
+    } else if let table = try? container.decode([String: TOMLValue].self) {
+      self = .table(table)
+    } else if let string = try? container.decode(String.self) {
+      self = .string(string)
+    } else if let integer = try? container.decode(Int.self) {
+      self = .integer(integer)
+    } else if let double = try? container.decode(Double.self) {
+      self = .double(double)
+    } else if let boolean = try? container.decode(Bool.self) {
+      self = .boolean(boolean)
+    } else {
+      throw Error(.failedToDecodeTOMLValue(CodingPath(container.codingPath)))
+    }
+  }
+
+  func encode(to encoder: any Encoder) throws {
+    var container = encoder.singleValueContainer()
+    switch self {
+      case let .dateTime(value):
+        try container.encode(value)
+      case let .date(value):
+        try container.encode(value)
+      case let .time(value):
+        try container.encode(value)
+      case let .array(value):
+        try container.encode(value)
+      case let .table(value):
+        try container.encode(value)
+      case let .string(value):
+        try container.encode(value)
+      case let .integer(value):
+        try container.encode(value)
+      case let .double(value):
+        try container.encode(value)
+      case let .boolean(value):
+        try container.encode(value)
+    }
+  }
+}

--- a/Sources/SwiftBundler/Configuration/TOMLValueError.swift
+++ b/Sources/SwiftBundler/Configuration/TOMLValueError.swift
@@ -1,0 +1,20 @@
+import ErrorKit
+
+extension TOMLValue {
+  typealias Error = RichError<ErrorMessage>
+
+  /// An error message related to ``TOMLValue``.
+  enum ErrorMessage: Throwable {
+    case failedToDecodeTOMLValue(CodingPath)
+
+    var userFriendlyMessage: String {
+      switch self {
+        case .failedToDecodeTOMLValue(let path):
+          return """
+            Failed to decode TOML value at \(path.description) as its type was \
+            not handled by TOMLValue; please file an issue at \(SwiftBundler.newIssueURL)
+            """
+      }
+    }
+  }
+}

--- a/Sources/SwiftBundler/Extensions/Version.swift
+++ b/Sources/SwiftBundler/Extensions/Version.swift
@@ -1,4 +1,6 @@
-import Version
+// Exported to make the Configuration macro work nicely. Its expansion
+// references Version.
+@_exported import struct Version.Version
 
 extension Version {
   /// A representation of the version using underscore separators and only including down to the least

--- a/Sources/SwiftBundler/SwiftBundler.swift
+++ b/Sources/SwiftBundler/SwiftBundler.swift
@@ -4,7 +4,24 @@ import Version
 
 /// The root command of Swift Bundler.
 public struct SwiftBundler: AsyncParsableCommand {
-  public static let version = Version(3, 0, 0)
+  /// The actual version of Swift Bundler.
+  private static let _version = Version(3, 0, 0)
+
+  /// The effective version of Swift Bundler. Under normal use this will match
+  /// ``_version``, but the `SBUN_EFFECTIVE_VERSION` environment variable can
+  /// be used to override the version that this build of Swift Bundler believes
+  /// it is. Overriding Swift Bundler's effective version is generally only done
+  /// to test configuration field deprecations and similar conditional behavior.
+  public static var version: Version {
+    if let effectiveVersion = ProcessInfo.processInfo.environment["_SBUN_EFFECTIVE_VERSION"],
+      let parsedVersion = Version(tolerant: effectiveVersion)
+    {
+      parsedVersion
+    } else {
+      _version
+    }
+  }
+
   public static let identifier = "dev.moreswift.swift-bundler"
 
   public static let configuration = CommandConfiguration(

--- a/Sources/SwiftBundler/SwiftBundlerErrorMapper.swift
+++ b/Sources/SwiftBundler/SwiftBundlerErrorMapper.swift
@@ -1,6 +1,7 @@
 import ErrorKit
 import Foundation
 import TOMLKit
+import Parsing
 
 /// An error mapper used by Swift Bundler to provide nicer variants of certain
 /// third-party errors.
@@ -34,6 +35,8 @@ public enum SwiftBundlerErrorMapper: ErrorMapper {
         return """
           TOML decoding error: \(error.debugDescription)
           """
+      case let error where "\(type(of: error))" == "ParsingError":
+        return String(describing: error)
       default:
         return nil
     }

--- a/Sources/SwiftBundlerMacrosPlugin/ConfigurationMacro.swift
+++ b/Sources/SwiftBundlerMacrosPlugin/ConfigurationMacro.swift
@@ -311,6 +311,8 @@ extension ConfigurationMacro {
       )
 
       try VariableDeclSyntax("var condition: OverlayCondition")
+      try VariableDeclSyntax("var lazyContent: [String: TOMLValue]")
+      try VariableDeclSyntax("var requiredConfigVersion: Version?")
 
       for property in properties {
         try VariableDeclSyntax("var \(raw: property.identifier): \(raw: property.overlayType)")
@@ -318,10 +320,84 @@ extension ConfigurationMacro {
 
       try EnumDeclSyntax("enum CodingKeys: String, CodingKey") {
         try EnumCaseDeclSyntax("case condition")
+        try EnumCaseDeclSyntax("case requiredConfigVersion = \"required_config_version\"")
 
         for property in properties {
           try EnumCaseDeclSyntax(
             "case \(raw: property.identifier) = \(StringLiteralExprSyntax(content: property.key))"
+          )
+        }
+      }
+
+      try InitializerDeclSyntax("init(from decoder: Decoder) throws") {
+        StmtSyntax("let container = try decoder.container(keyedBy: StringCodingKey.self)\n")
+
+        // Parse the required config version first (if present) so that we can
+        // early exit.
+        StmtSyntax(
+          """
+          self.requiredConfigVersion = container.contains(StringCodingKey(CodingKeys.requiredConfigVersion.stringValue))
+            ? try container.decode(
+              Version.self,
+              forKey: StringCodingKey(CodingKeys.requiredConfigVersion.stringValue)
+            )
+            : nil
+
+          """
+        )
+
+        // I'm not sure why we need to do this, but some things fail to compile without it
+        let initPropertiesToNil = properties.map { property in
+          """
+          self.\(property.identifier) = nil
+          """
+        }.joined(separator: "\n")
+
+        // Early exit if the overlay requires a newer Swift Bundler version than
+        // currently in use
+        StmtSyntax(
+          """
+          if let requiredConfigVersion,
+            let version = decoder.userInfo[.swiftBundlerVersion] as? Version,
+            requiredConfigVersion > version
+          {
+            if version < Version(3, 1, 0) {
+              throw PackageConfiguration.Error(
+                .requiredConfigVersionNotSupportedInOverlays
+              )
+            }
+
+            self.condition = .false
+            \(raw: initPropertiesToNil)
+
+            var lazyContent: [String: TOMLValue] = [:]
+            for key in container.allKeys {
+              lazyContent[key.stringValue] = try container.decode(TOMLValue.self, forKey: key)
+            }
+            self.lazyContent = lazyContent
+            return
+          } else {
+            self.lazyContent = [:]
+          }
+
+          """
+        )
+
+        StmtSyntax("self.condition = try container.decode(OverlayCondition.self, forKey: StringCodingKey(CodingKeys.condition.stringValue))\n")
+
+        for property in properties {
+          StmtSyntax(
+            """
+            if container.contains(StringCodingKey(CodingKeys.\(raw: property.identifier).stringValue)) {
+              self.\(raw: property.identifier) = try container.decode(
+                \(raw: property.overlayType).self,
+                forKey: StringCodingKey(CodingKeys.\(raw: property.identifier).stringValue)
+              )
+            } else {
+              self.\(raw: property.identifier) = nil
+            }
+
+            """
           )
         }
       }

--- a/Sources/SwiftBundlerMacrosPlugin/ConfigurationMacro.swift
+++ b/Sources/SwiftBundlerMacrosPlugin/ConfigurationMacro.swift
@@ -358,7 +358,7 @@ extension ConfigurationMacro {
         StmtSyntax(
           """
           if let requiredConfigVersion,
-            let version = decoder.userInfo[.swiftBundlerVersion] as? Version,
+            let version = decoder.userInfo[.swiftBundlerConfigVersion] as? Version,
             requiredConfigVersion > version
           {
             if version < Version(3, 1, 0) {

--- a/Sources/SwiftBundlerMacrosPlugin/ConfigurationMacro.swift
+++ b/Sources/SwiftBundlerMacrosPlugin/ConfigurationMacro.swift
@@ -357,16 +357,35 @@ extension ConfigurationMacro {
         // currently in use
         StmtSyntax(
           """
-          if let requiredConfigVersion,
-            let version = decoder.userInfo[.swiftBundlerConfigVersion] as? Version,
-            requiredConfigVersion > version
-          {
-            if version < Version(3, 1, 0) {
+          if let requiredConfigVersion {
+            if let version = decoder.userInfo[.swiftBundlerConfigVersion] as? Version,
+              version < Version(3, 1, 0)
+            {
               throw PackageConfiguration.Error(
-                .requiredConfigVersionNotSupportedInOverlays
+                .requiredConfigVersionFieldNotSupportedByConfigVersion
               )
             }
 
+            if let version = decoder.userInfo[.swiftBundlerConfigVersion] as? Version,
+              requiredConfigVersion <= version
+            {
+              throw PackageConfiguration.Error(
+                .requiredConfigVersionNotHigherThanConfigVersion(
+                  requiredConfigVersion,
+                  version,
+                  CodingPath(container.codingPath)
+                )
+              )
+            }
+          }
+          """
+        )
+
+        StmtSyntax(
+          """
+          if let requiredConfigVersion,
+            requiredConfigVersion > SwiftBundler.version
+          {
             self.condition = .false
             \(raw: initPropertiesToNil)
 


### PR DESCRIPTION
This allows users to use newer Swift Bundler features in config files that still support older config versions. This is most useful for library developers.

As with many of our other configuration format changes, 3.0.0 understands the changes, and technically has the code to support the change, but will throw an error about the change only being enabled in 3.1.0. We will remove the errors in 3.1.0.

The version gating is done to avoid existing `format_version` configuration files from using features that defacto 3.0.0 builds don't support.