### PR TITLE
Support new Swift Build System in Swift v6.2+

### DIFF
--- a/Sources/SwiftBundler/Commands/BundleArguments.swift
+++ b/Sources/SwiftBundler/Commands/BundleArguments.swift
@@ -292,4 +292,19 @@ struct BundleArguments: ParsableArguments {
       """
   )
   var skipDependencies = false
+  
+  #if compiler(>=6.2)
+    /// Whether to use the new Swift Build system.
+    @Flag(
+      name: .customLong("experimental-swiftbuild"),
+      help: """
+        Use the new Swift Build system which is the default SwiftPM build \
+        system in nightly snapshots of Swift's 'main' branches. As of Swift 6.2 \
+        and 6.3, it can be enabled by passing '--build-system swiftbuild' to the \
+        'swift build' command.
+        """
+    )
+    var useNewSwiftBuild = false
+  #endif
+
 }

--- a/Sources/SwiftBundler/Commands/BundleCommand.swift
+++ b/Sources/SwiftBundler/Commands/BundleCommand.swift
@@ -198,9 +198,14 @@ struct BundleCommand: ErrorHandledCommand {
         return false
       }
       if arguments.useNewSwiftBuild && arguments.additionalSwiftPMArguments.contains("--build-system") {
-        log.warning(
-          "'--build-system' is already set via '--Xswiftpm', ignoring '--experimental-swiftbuild'"
+        log.error(
+          """
+          The build system was specified twice via '--experimental-swiftbuild' and \
+          '--Xswiftpm --build-system'. Use '--Xswiftpm --build-system' instead \
+          or omit '--experimental-swiftbuild'.
+          """
         )
+        return false
       }
     #endif
 

--- a/Sources/SwiftBundler/Commands/BundleCommand.swift
+++ b/Sources/SwiftBundler/Commands/BundleCommand.swift
@@ -186,6 +186,23 @@ struct BundleCommand: ErrorHandledCommand {
       )
       return false
     }
+    
+    #if compiler(>=6.2)
+      if arguments.xcodebuild && arguments.useNewSwiftBuild {
+        log.error(
+          """
+          '--experimental-swiftbuild' only works when building with the SwiftPM build system. \
+          Remove '--xcodebuild' to build with the new Swift Build system instead.
+          """
+        )
+        return false
+      }
+      if arguments.useNewSwiftBuild && arguments.additionalSwiftPMArguments.contains("--build-system") {
+        log.warning(
+          "'--build-system' is already set via '--Xswiftpm', ignoring '--experimental-swiftbuild'"
+        )
+      }
+    #endif
 
     // macOS-only arguments
     #if os(macOS)
@@ -891,6 +908,13 @@ struct BundleCommand: ErrorHandledCommand {
         compiledMetadata = nil
       }
 
+      var swiftPMArguments = arguments.additionalSwiftPMArguments
+      #if compiler(>=6.2)
+        if arguments.useNewSwiftBuild && !swiftPMArguments.contains("--build-system") {
+          swiftPMArguments += ["--build-system", "swiftbuild"]
+        }
+      #endif
+
       let buildContext = SwiftPackageManager.BuildContext(
         genericContext: GenericBuildContext(
           projectDirectory: context.packageDirectory,
@@ -901,7 +925,7 @@ struct BundleCommand: ErrorHandledCommand {
           platformVersion: context.platformVersion,
           additionalArguments: isUsingXcodebuild
             ? arguments.additionalXcodeBuildArguments
-            : arguments.additionalSwiftPMArguments
+            : swiftPMArguments
         ),
         toolchain: context.toolchain,
         hotReloadingEnabled: hotReloadingEnabled,


### PR DESCRIPTION
Use the new [**Swift Build** system](https://github.com/swiftlang/swift-build) — the default SwiftPM build system in nightly Swift `main` snapshots. As of Swift 6.2+, it can be enabled by passing `--build-system swiftbuild` to `swift build`.

Wires up the `--experimental-swiftbuild` flag to pass `--build-system swiftbuild` to SwiftPM when bundling or running.

**Changes**
- Append `--build-system swiftbuild` to SwiftPM arguments when `--experimental-swiftbuild` is set (Swift 6.2+ only)
- Error if `--experimental-swiftbuild` and `--xcodebuild` are both passed.
- Error if `--experimental-swiftbuild` and `--Xswiftpm --build-system` are both passed.