### PR TITLE
Windows: Avoid re-signing presigned artifacts

### DIFF
--- a/Sources/SwiftBundler/Bundler/GenericWindowsBundler.swift
+++ b/Sources/SwiftBundler/Bundler/GenericWindowsBundler.swift
@@ -405,6 +405,15 @@ enum GenericWindowsBundler: Bundler {
         let isExecutable = artifact.location.pathExtension == "exe"
         if isExecutable, let codeSigningContext = context.windowsCodeSigningContext {
           try await Error.catch {
+            // Don't re-sign the file if it's already signed (it was probably
+            // downloaded from the internet or built by an external build system
+            // that already handles signing). If the file has a signature but not
+            // one that we trust, then we proceed with re-signing the executable.
+            let isSigned = try await WindowsCodeSigner.fileHasTrustedSignature(destination)
+            guard !isSigned else {
+              return
+            }
+
             try await WindowsCodeSigner.signFile(
               destination,
               context: codeSigningContext

--- a/Sources/SwiftBundler/Bundler/WindowsCodeSigner.swift
+++ b/Sources/SwiftBundler/Bundler/WindowsCodeSigner.swift
@@ -14,6 +14,28 @@ enum WindowsCodeSigner {
   static let azureArtifactSigningNUPKG =
     URL(string: "https://www.nuget.org/api/v2/package/Microsoft.ArtifactSigning.Client/1.0.128")!
 
+  /// Checks whether a file is signed or not. Returns `true` if and only if the
+  /// binary is signed by a certificate that this computer trusts.
+  static func fileHasTrustedSignature(_ file: URL) async throws(Error) -> Bool {
+    guard file.exists(withType: .file) else {
+      throw Error(.fileDoesNotExist(file))
+    }
+
+    do {
+      try await Process.create(
+        "SignTool",
+        arguments: [
+          "verify",
+          "/pa",
+          file.path
+        ]
+      ).runAndWait()
+      return true
+    } catch {
+      return false
+    }
+  }
+
   /// Signs a file using the given code signing context. Also securely timestamps the file.
   static func signFile(
     _ file: URL,

--- a/Sources/SwiftBundler/Bundler/WindowsCodeSignerError.swift
+++ b/Sources/SwiftBundler/Bundler/WindowsCodeSignerError.swift
@@ -1,4 +1,5 @@
 import ErrorKit
+import Foundation
 
 extension WindowsCodeSigner {
   typealias Error = RichError<ErrorMessage>
@@ -8,6 +9,7 @@ extension WindowsCodeSigner {
     case failedToLoadCertificateStore(_ identifier: String)
     case identityNotFound(_ searchTerm: String)
     case failedToDownloadArtifactSigningClient
+    case fileDoesNotExist(URL)
 
     var userFriendlyMessage: String {
       switch self {
@@ -17,6 +19,8 @@ extension WindowsCodeSigner {
           return "Code signing identity not found for search term '\(searchTerm)'"
         case .failedToDownloadArtifactSigningClient:
           return "Failed to download Azure Artifact Signing Client"
+        case .fileDoesNotExist(let file):
+          return "File does not exist at '\(file.path)'"
       }
     }
   }


### PR DESCRIPTION
Previously we automatically signed all executable artifacts produced by a build (including helper executables, and prebuilt executables downloaded from the internet as part of the build). This is functionally sound, but sometimes leads to us clobbering the signatures of binaries that have already been signed (such as the Windows App Runtime Installer). Doing so means that users have to place more trust in the application developer to not tinker with third party dependencies and installers.

This PR updates the Windows signing code to only sign helper executables if they don't already have a valid *and* trusted signature.